### PR TITLE
fix: pycln version to 2.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v1.2.5
+    rev: v2.4.0
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]


### PR DESCRIPTION
make devcontainer work again