### PR TITLE
fix: replace wrong None check

### DIFF
--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -136,7 +136,7 @@ class ConI:
         self.model_read()
 
     def __del__(self):
-        if None is not self.__session:
+        if self.__session is not None:
             self.logout()
 
     def __enter__(self):

--- a/src/odsbox/submatrix_to_pandas.py
+++ b/src/odsbox/submatrix_to_pandas.py
@@ -80,7 +80,7 @@ def __convert_bulk_to_pandas_data_frame(
             ]
 
     rv = pd.DataFrame(column_dict)
-    if None is not independent_local_column_name:
+    if independent_local_column_name is not None:
         rv.set_index(independent_local_column_name)
 
     return rv

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -10,7 +10,7 @@ import pytest
 
 def __create_con_i():
     """Create a connection session for an ASAM ODS server"""
-    return ConI("http://79.140.180.128:10032/api", ("sa", "sa"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
 
 
 def test_con_i():

--- a/tests/test_con_i_file_access.py
+++ b/tests/test_con_i_file_access.py
@@ -12,7 +12,7 @@ from odsbox.proto.ods_pb2 import FileIdentifier
 
 @pytest.fixture
 def con_i():
-    return ConI("http://79.140.180.128:10032/api", ("sa", "sa"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
 
 
 def test_file_access_download_success(con_i):

--- a/tests/test_unit_catalog.py
+++ b/tests/test_unit_catalog.py
@@ -8,7 +8,7 @@ import pytest
 
 def __create_con_i():
     """Create a connection session for an ASAM ODS server"""
-    return ConI("http://79.140.180.128:10032/api", ("sa", "sa"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
 
 
 def test_unit_get():

--- a/tests/test_unit_utils.py
+++ b/tests/test_unit_utils.py
@@ -8,7 +8,7 @@ import logging
 
 def __create_con_i():
     """Create a connection session for an ASAM ODS server"""
-    return ConI("http://79.140.180.128:10032/api", ("sa", "sa"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
 
 
 def test_query_units():


### PR DESCRIPTION
This pull request includes minor changes to improve the readability and consistency of conditional statements in the codebase. The changes primarily involve updating the syntax for checking if a variable is not `None`.

Code readability improvements:

* [`src/odsbox/con_i.py`](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422L139-R139): Updated the `__del__` method to use a more readable condition for checking if `self.__session` is not `None`.
* [`src/odsbox/submatrix_to_pandas.py`](diffhunk://#diff-dd1d1aa0ac96edca44a7bc5f76c13ea5f0335483b6f13ae4e1a99502ef2e8c49L83-R83): Modified the `__convert_bulk_to_pandas_data_frame` function to use a more readable condition for checking if `independent_local_column_name` is not `None`.