### PR TITLE
fix: #95 preserve direction of outer join

### DIFF
--- a/src/odsbox/jaquel.py
+++ b/src/odsbox/jaquel.py
@@ -250,7 +250,12 @@ def __parse_path_and_add_joins(
             attribute_name = relation.name
 
             # add join
-            if (-1 == relation.range_max) and (1 == relation.inverse_range_max):
+            if (
+                (-1 == relation.range_max)
+                and (1 == relation.inverse_range_max)
+                and join_type != ods.SelectStatement.JoinItem.JoinTypeEnum.JT_OUTER
+            ):
+                # in case of OUTER join the direction is important and must be like addressed
                 inverse_entity = model.entities[relation.entity_name]
                 inverse_relation = inverse_entity.relations[relation.inverse_name]
                 __add_join_to_seq(model, inverse_entity, inverse_relation, joins, join_type)

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -82,3 +82,24 @@ def test_submatrix_load():
             logging.getLogger().info(submatrix_id)
             submatrix_dataframe = submatrix_to_pandas(con_i, submatrix_id)
             assert submatrix_dataframe is not None
+
+
+def test_bug_93_outer_join_on_n_relation():
+    logging.getLogger().info(
+        "In case of outer join the direction is important and must point from n to 1 when generated from jaquel."
+    )
+    with __create_con_i() as con_i:
+        df = con_i.query_data(
+            {
+                "AoMeasurement": {},
+                "$attributes": {
+                    "name": 1,
+                    "measurement_quantities:OUTER": {"name": 1, "unit:OUTER.name": 1},
+                    "submatrices:OUTER.name": 1,
+                },
+                "$options": {"$rowlimit": 10},
+            }
+        )
+        assert df is not None
+        assert df.empty is False
+        assert 4 == len(df.columns)

--- a/tests/test_data/jaquel/bugs/bug_93_outer_join_must_preserve_direction.json
+++ b/tests/test_data/jaquel/bugs/bug_93_outer_join_must_preserve_direction.json
@@ -1,0 +1,14 @@
+{
+    "AoMeasurement": {},
+    "$attributes": {
+        "name": 1,
+        "measurement_quantities:OUTER": {
+            "name": 1,
+            "unit:OUTER.name": 1
+        },
+        "submatrices:OUTER.name": 1
+    },
+    "$options": {
+        "$rowlimit": 10
+    }
+}

--- a/tests/test_data/jaquel/bugs/bug_93_outer_join_must_preserve_direction.json.proto
+++ b/tests/test_data/jaquel/bugs/bug_93_outer_join_must_preserve_direction.json.proto
@@ -1,0 +1,41 @@
+{
+    "columns": [
+        {
+            "aid": "79",
+            "attribute": "Name"
+        },
+        {
+            "aid": "80",
+            "attribute": "Name"
+        },
+        {
+            "aid": "54",
+            "attribute": "Name"
+        },
+        {
+            "aid": "81",
+            "attribute": "Name"
+        }
+    ],
+    "joins": [
+        {
+            "aidFrom": "79",
+            "aidTo": "80",
+            "relation": "MeaQuantities",
+            "joinType": "JT_OUTER"
+        },
+        {
+            "aidFrom": "80",
+            "aidTo": "54",
+            "relation": "Unit",
+            "joinType": "JT_OUTER"
+        },
+        {
+            "aidFrom": "79",
+            "aidTo": "81",
+            "relation": "SubMatrices",
+            "joinType": "JT_OUTER"
+        }
+    ],
+    "rowLimit": "10"
+}

--- a/tests/test_jaquel_convert.py
+++ b/tests/test_jaquel_convert.py
@@ -87,6 +87,10 @@ def test_predefined():
             Path(str(path) + ".proto").read_text(encoding="utf-8"),
             select_statement_ref,
         )
+        if select_statement_ref != select_statement:
+            select_statement_json = MessageToJson(select_statement)
+            logging.getLogger().info(select_statement_json)
+
         assert select_statement_ref == select_statement
 
 


### PR DESCRIPTION
This pull request addresses a bug related to preserving the direction of outer joins in the Jaquel query language. The changes include modifications to the core logic for parsing joins, as well as the addition of new tests to verify the correct behavior.