### PR TITLE
feat: allow to avoid model_read in constructor of ConI

### DIFF
--- a/src/odsbox/__init__.py
+++ b/src/odsbox/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -65,6 +65,7 @@ class ConI:
         auth: requests.auth.AuthBase | Tuple[str, str] = ("sa", "sa"),
         context_variables: ods.ContextVariables | dict | None = None,
         verify_certificate: bool = True,
+        load_model: bool = True,
     ):
         """
         Create a session object keeping track of ASAM ODS session URL named `conI`.
@@ -107,8 +108,12 @@ class ConI:
             connection they are passed here. It defaults to None.
         :param bool verify_certificate: If no certificate is provided for https insecure access can be enabled.
             It defaults to True.
+        :param bool load_model: If the model should be read after connection is established. It defaults to True.
         :raises requests.HTTPError: If connection to ASAM ODS server fails.
         """
+        self.__session = None
+        self.__con_i = None
+
         session = requests.Session()
         session.auth = auth
         session.verify = verify_certificate
@@ -134,8 +139,9 @@ class ConI:
             self.__session = session
             self.__con_i = con_i
         self.check_requests_response(response)
-        # lets cache the model
-        self.model_read()
+        if load_model:
+            # lets cache the model
+            self.model_read()
 
     def __del__(self):
         if self.__session is not None:
@@ -649,7 +655,7 @@ class ConI:
         :return ods.ModelCache: ModelCache object containing the cached application model.
         """
         if self.__mc is None:
-            raise ValueError("No open session!")
+            raise ValueError("Model not read! Call model_read() first.")
         return self.__mc
 
     @property

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -16,9 +16,9 @@ import os
 import tempfile
 
 
-def __create_con_i():
+def __create_con_i(load_model: bool = True) -> ConI:
     """Create a connection session for an ASAM ODS server"""
-    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"), load_model=load_model)
 
 
 def test_con_i():
@@ -361,3 +361,17 @@ def test_security_level():
         assert Security.Level.ELEMENT not in security_level
 
     assert 7 == int(Security.Level.ELEMENT | Security.Level.INSTANCE | Security.Level.ATTRIBUTE)
+
+
+def test_do_not_load_model():
+    """Test that ConI can be created without loading the model"""
+    with __create_con_i(False) as con_i:
+        with pytest.raises(ValueError):
+            _ = con_i.mc
+        with pytest.raises(ValueError):
+            _ = con_i.model()
+        # update model
+        assert con_i.model_read() is not None
+        # Access the cached model
+        assert con_i.mc is not None
+        con_i.model()


### PR DESCRIPTION
To allow boostrap usage add a parameter to suppress model_read call on creating ConI.