### PR TITLE
feat: Allow to avoid model_read in constructor of ConI

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -15,4 +15,4 @@ jobs:
       id-token: write
     steps:
     - id: deployment
-      uses: sphinx-notes/pages@3.2
+      uses: sphinx-notes/pages@3.4

--- a/docs/odsbox.rst
+++ b/docs/odsbox.rst
@@ -61,3 +61,10 @@ asam_time
 .. automodule:: odsbox.asam_time
    :members:
    :show-inheritance:
+
+security
+---------
+
+.. automodule:: odsbox.security
+   :members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "pre-commit==4.2.0",
     "pylint==3.3.7",
     "pylint_junit",
-    "pytest-cov==6.1.1",
+    "pytest-cov==6.2.1",
     "pytest-mock<3.14.2",
     "pytest-runner",
     "pytest==8.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
     "pytest-cov==6.1.1",
     "pytest-mock<3.14.2",
     "pytest-runner",
-    "pytest==8.3.5",
+    "pytest==8.4.0",
     "pytest-github-actions-annotate-failures",
     "pytest-xdist",
     "shellcheck-py==0.10.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
     "pytest-cov==6.2.1",
     "pytest-mock<3.14.2",
     "pytest-runner",
-    "pytest==8.4.0",
+    "pytest==8.4.1",
     "pytest-github-actions-annotate-failures",
     "pytest-xdist",
     "shellcheck-py==0.10.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 exd-data = ["grpcio>=1.59.3,<2.0.0"]
 test = [
-    "bandit[toml]==1.8.3",
+    "bandit[toml]==1.8.5",
     "black==25.1.0",
     "check-manifest==0.50",
     "flake8-bugbear==24.12.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pylint==3.3.7",
     "pylint_junit",
     "pytest-cov==6.1.1",
-    "pytest-mock<3.14.1",
+    "pytest-mock<3.14.2",
     "pytest-runner",
     "pytest==8.3.5",
     "pytest-github-actions-annotate-failures",

--- a/src/odsbox/__init__.py
+++ b/src/odsbox/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -65,6 +65,7 @@ class ConI:
         auth: requests.auth.AuthBase | Tuple[str, str] = ("sa", "sa"),
         context_variables: ods.ContextVariables | dict | None = None,
         verify_certificate: bool = True,
+        load_model: bool = True,
     ):
         """
         Create a session object keeping track of ASAM ODS session URL named `conI`.
@@ -107,8 +108,12 @@ class ConI:
             connection they are passed here. It defaults to None.
         :param bool verify_certificate: If no certificate is provided for https insecure access can be enabled.
             It defaults to True.
+        :param bool load_model: If the model should be read after connection is established. It defaults to True.
         :raises requests.HTTPError: If connection to ASAM ODS server fails.
         """
+        self.__session = None
+        self.__con_i = None
+
         session = requests.Session()
         session.auth = auth
         session.verify = verify_certificate
@@ -134,8 +139,9 @@ class ConI:
             self.__session = session
             self.__con_i = con_i
         self.check_requests_response(response)
-        # lets cache the model
-        self.model_read()
+        if load_model:
+            # lets cache the model
+            self.model_read()
 
     def __del__(self):
         if self.__session is not None:
@@ -649,7 +655,7 @@ class ConI:
         :return ods.ModelCache: ModelCache object containing the cached application model.
         """
         if self.__mc is None:
-            raise ValueError("No open session!")
+            raise ValueError("Model not read! Call model_read() first.")
         return self.__mc
 
     @property

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -16,9 +16,9 @@ import os
 import tempfile
 
 
-def __create_con_i():
+def __create_con_i(load_model: bool = True) -> ConI:
     """Create a connection session for an ASAM ODS server"""
-    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"))
+    return ConI("https://docker.peak-solution.de:10032/api", ("Demo", "mdm"), load_model=load_model)
 
 
 def test_con_i():
@@ -361,3 +361,17 @@ def test_security_level():
         assert Security.Level.ELEMENT not in security_level
 
     assert 7 == int(Security.Level.ELEMENT | Security.Level.INSTANCE | Security.Level.ATTRIBUTE)
+
+
+def test_do_not_load_model():
+    """Test that ConI can be created without loading the model"""
+    with __create_con_i(False) as con_i:
+        with pytest.raises(ValueError):
+            _ = con_i.mc
+        with pytest.raises(ValueError):
+            _ = con_i.model()
+        # update model
+        assert con_i.model_read() is not None
+        # Access the cached model
+        assert con_i.mc is not None
+        con_i.model()


### PR DESCRIPTION
This pull request introduces several updates across different areas of the codebase, including dependency upgrades, feature additions, and enhancements to testing and documentation. The most significant changes focus on improving functionality in the `ConI` class, updating dependencies, and extending documentation.

### Feature Enhancements:
* [`src/odsbox/con_i.py`](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R68): Added a `load_model` parameter to the `ConI` class, allowing users to control whether the model is loaded during connection initialization. Updated the `mc` method to raise a specific error if the model is not loaded. [[1]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R68) [[2]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R111-R116) [[3]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R142) [[4]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422L652-R658)

### Dependency Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L42-R42): Upgraded testing dependencies, including `pytest`, `pytest-cov`, and `pytest-mock`, to newer versions for improved compatibility and functionality. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L42-R42) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L53-R56)

### Testing Improvements:
* [`tests/test_con_i.py`](diffhunk://#diff-1db0b2d380777aee6760d6c7c38eeae1c7c3594d53eef01bd6bf3852d46125c7R364-R377): Added a new test, `test_do_not_load_model`, to verify that the `ConI` class can be created without loading the model and that the model can be loaded later as needed.

### Documentation Updates:
* [`docs/odsbox.rst`](diffhunk://#diff-1442b83ad17c07b75b5cfbf0f4b073e511af3aabe02f4d6115251af047501cd0R64-R70): Added a new section for `odsbox.security` to the documentation, including inheritance and member details.

### Workflow Updates:
* [`.github/workflows/sphinx.yml`](diffhunk://#diff-3b5400f13c20505910b5f51111b34c0c17ad7137e82e2859cef6ee5a09e77f8dL18-R18): Updated the `sphinx-notes/pages` action from version `3.2` to `3.4`.