### PR TITLE
feat: 129 check message type of input parameter

### DIFF
--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -233,6 +233,8 @@ class ConI:
         :return ods.DataMatrices: The DataMatrices representing the result.
             It will contain one ods.DataMatrix for each returned entity type.
         """
+        if not isinstance(select_statement, ods.SelectStatement):
+            raise TypeError(f"data_read expects 'ods.SelectStatement', got '{type(select_statement).__name__}'")
         response = self.ods_post_request("data-read", select_statement)
         return_value = ods.DataMatrices()
         return_value.ParseFromString(response.content)
@@ -246,6 +248,8 @@ class ConI:
         :raises requests.HTTPError: If creation fails.
         :return List[int]: list of ids created from your request.
         """
+        if not isinstance(data, ods.DataMatrices):
+            raise TypeError(f"data_create expects 'ods.DataMatrices', got '{type(data).__name__}'")
         response = self.ods_post_request("data-create", data)
         return_value = ods.DataMatrices()
         return_value.ParseFromString(response.content)
@@ -259,6 +263,8 @@ class ConI:
             The `id` column is used to identify the instances to be updated.
         :raises requests.HTTPError: If update fails.
         """
+        if not isinstance(data, ods.DataMatrices):
+            raise TypeError(f"data_update expects 'ods.DataMatrices', got '{type(data).__name__}'")
         self.ods_post_request("data-update", data)
 
     def data_delete(self, data: ods.DataMatrices) -> None:
@@ -269,6 +275,8 @@ class ConI:
             The `id` column is used to identify the instances to be deleted.
         :raises requests.HTTPError: If delete fails.
         """
+        if not isinstance(data, ods.DataMatrices):
+            raise TypeError(f"data_delete expects 'ods.DataMatrices', got '{type(data).__name__}'")
         self.ods_post_request("data-delete", data)
 
     def data_copy(self, copy_request: ods.CopyRequest) -> ods.Instance:
@@ -279,6 +287,8 @@ class ConI:
         :raises requests.HTTPError: If copy fails.
         :return ods.Instance: Newly created instance
         """
+        if not isinstance(copy_request, ods.CopyRequest):
+            raise TypeError(f"data_copy expects 'ods.CopyRequest', got '{type(copy_request).__name__}'")
         response = self.ods_post_request("data-copy", copy_request)
         return_value = ods.Instance()
         return_value.ParseFromString(response.content)
@@ -292,6 +302,10 @@ class ConI:
         :raises requests.HTTPError: If read fails.
         :return ods.NtoMRelatedInstances: Return n to m related instances that were queried.
         """
+        if not isinstance(identifier, ods.NtoMRelationIdentifier):
+            raise TypeError(
+                f"n_m_relation_read expects 'ods.NtoMRelationIdentifier', got '{type(identifier).__name__}'"
+            )
         response = self.ods_post_request("n-m-relation-read", identifier)
         return_value = ods.NtoMRelatedInstances()
         return_value.ParseFromString(response.content)
@@ -305,6 +319,10 @@ class ConI:
         :param ods.NtoMWriteRelatedInstances related_instances: related instances to be
             updated, deleted or created.
         """
+        if not isinstance(related_instances, ods.NtoMWriteRelatedInstances):
+            raise TypeError(
+                f"n_m_relation_write expects 'ods.NtoMWriteRelatedInstances', got '{type(related_instances).__name__}'"
+            )
         self.ods_post_request("n-m-relation-write", related_instances)
 
     def transaction(self) -> Transaction:
@@ -353,6 +371,8 @@ class ConI:
         :raises requests.HTTPError: If ValueMatrix access fails.
         :return ods.DataMatrices: DataMatrices containing the bulk data for the request.
         """
+        if not isinstance(request, ods.ValueMatrixRequestStruct):
+            raise TypeError(f"valuematrix_read expects 'ods.ValueMatrixRequestStruct', got '{type(request).__name__}'")
         response = self.ods_post_request("valuematrix-read", request)
         return_value = ods.DataMatrices()
         return_value.ParseFromString(response.content)
@@ -381,6 +401,8 @@ class ConI:
             updated by reading the whole model again. It defaults to True.
         :raises requests.HTTPError: If model update fails.
         """
+        if not isinstance(model_parts, ods.Model):
+            raise TypeError(f"model_update expects 'ods.Model', got '{type(model_parts).__name__}'")
         self.ods_post_request("model-update", model_parts)
         if update_model:
             # cache again if successfully changed
@@ -395,6 +417,8 @@ class ConI:
             updated by reading the whole model again. It defaults to True.
         :raises requests.HTTPError: If model update fails.
         """
+        if not isinstance(model_parts, ods.Model):
+            raise TypeError(f"model_delete expects 'ods.Model', got '{type(model_parts).__name__}'")
         self.ods_post_request("model-delete", model_parts)
         if update_model:
             # cache again if successfully changed
@@ -428,6 +452,8 @@ class ConI:
         :raises requests.HTTPError: If creation fails.
         :return ods.AsamPath: The AsamPath that represents the instance.
         """
+        if not isinstance(instance, ods.Instance):
+            raise TypeError(f"asampath_create expects 'ods.Instance', got '{type(instance).__name__}'")
         response = self.ods_post_request("asampath-create", instance)
         return_value = ods.AsamPath()
         return_value.ParseFromString(response.content)
@@ -441,6 +467,8 @@ class ConI:
         :raises requests.HTTPError: If path could not be resolved.
         :return ods.Instance: Instance represented by AsamPath.
         """
+        if not isinstance(asam_path, ods.AsamPath):
+            raise TypeError(f"asampath_resolve expects 'ods.AsamPath', got '{type(asam_path).__name__}'")
         response = self.ods_post_request("asampath-resolve", asam_path)
         return_value = ods.Instance()
         return_value.ParseFromString(response.content)
@@ -473,6 +501,8 @@ class ConI:
         :param ods.ContextVariables context_variables: ContextVariables to be set or updated.
         :raises requests.HTTPError: If something went wrong.
         """
+        if not isinstance(context_variables, ods.ContextVariables):
+            raise TypeError(f"context_update expects 'ods.ContextVariables', got '{type(context_variables).__name__}'")
         self.ods_post_request("context-update", context_variables)
 
     def password_update(self, password_update: ods.PasswordUpdate) -> None:
@@ -482,6 +512,8 @@ class ConI:
         :param ods.PasswordUpdate password_update: Defines for which user the password should eb updated.
         :raises requests.HTTPError: If something went wrong.
         """
+        if not isinstance(password_update, ods.PasswordUpdate):
+            raise TypeError(f"password_update expects 'ods.PasswordUpdate', got '{type(password_update).__name__}'")
         self.ods_post_request("password-update", password_update)
 
     def file_access(self, file_identifier: ods.FileIdentifier) -> str:
@@ -494,6 +526,8 @@ class ConI:
         :raises ValueError: If no file location provided by server.
         :return str: The server file URL.
         """
+        if not isinstance(file_identifier, ods.FileIdentifier):
+            raise TypeError(f"file_access expects 'ods.FileIdentifier', got '{type(file_identifier).__name__}'")
         response = self.ods_post_request("file-access", file_identifier)
         server_file_url = response.headers.get("location")
         if server_file_url is None:
@@ -521,6 +555,10 @@ class ConI:
         :raises ValueError: If no open session.
         :return str: file path of saved file.
         """
+        if not isinstance(file_identifier, ods.FileIdentifier):
+            raise TypeError(
+                f"file_access_download expects 'ods.FileIdentifier', got '{type(file_identifier).__name__}'"
+            )
         server_file_url = self.file_access(file_identifier)
 
         if self.__session is None:
@@ -568,6 +606,8 @@ class ConI:
         :raises FileNotFoundError: If source file was not found.
         :raises ValueError: If no open session.
         """
+        if not isinstance(file_identifier, ods.FileIdentifier):
+            raise TypeError(f"file_access_upload expects 'ods.FileIdentifier', got '{type(file_identifier).__name__}'")
         if not os.path.isfile(source_file_path):
             raise FileNotFoundError(f"File '{source_file_path}' not found.")
 
@@ -595,6 +635,8 @@ class ConI:
         :raises requests.HTTPError: If something went wrong.
         :raises ValueError: If no open session.
         """
+        if not isinstance(file_identifier, ods.FileIdentifier):
+            raise TypeError(f"file_access_delete expects 'ods.FileIdentifier', got '{type(file_identifier).__name__}'")
         server_file_url = self.file_access(file_identifier)
 
         if self.__session is None:

--- a/tests/test_con_i_type_error.py
+++ b/tests/test_con_i_type_error.py
@@ -1,0 +1,123 @@
+# Negative type-check tests for ConI methods
+import pytest
+from odsbox.con_i import ConI
+from odsbox.proto.ods_pb2 import DataMatrix
+
+
+@pytest.fixture
+def dummy_con_i():
+    # create without running __init__
+    con_i = ConI.__new__(ConI)
+    con_i._ConI__session = None  # type: ignore
+    return con_i
+
+
+# Negative type-check tests
+
+
+def test_data_read_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.data_read("invalid")
+    assert "data_read expects 'ods.SelectStatement'" in str(exc.value)
+
+
+def test_data_create_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.data_create(123)
+    assert "data_create expects 'ods.DataMatrices'" in str(exc.value)
+
+
+def test_data_update_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.data_update(DataMatrix())
+    assert "data_update expects 'ods.DataMatrices'" in str(exc.value)
+
+
+def test_data_delete_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.data_delete([])
+    assert "data_delete expects 'ods.DataMatrices'" in str(exc.value)
+
+
+def test_data_copy_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.data_copy({})
+    assert "data_copy expects 'ods.CopyRequest'" in str(exc.value)
+
+
+def test_n_m_relation_read_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.n_m_relation_read(3.14)
+    assert "n_m_relation_read expects 'ods.NtoMRelationIdentifier'" in str(exc.value)
+
+
+def test_n_m_relation_write_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.n_m_relation_write("wrong")
+    assert "n_m_relation_write expects 'ods.NtoMWriteRelatedInstances'" in str(exc.value)
+
+
+def test_valuematrix_read_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.valuematrix_read(())
+    assert "valuematrix_read expects 'ods.ValueMatrixRequestStruct'" in str(exc.value)
+
+
+def test_model_update_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.model_update([])
+    assert "model_update expects 'ods.Model'" in str(exc.value)
+
+
+def test_model_delete_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.model_delete(0)
+    assert "model_delete expects 'ods.Model'" in str(exc.value)
+
+
+def test_asampath_create_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.asampath_create(42)
+    assert "asampath_create expects 'ods.Instance'" in str(exc.value)
+
+
+def test_asampath_resolve_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.asampath_resolve(None)
+    assert "asampath_resolve expects 'ods.AsamPath'" in str(exc.value)
+
+
+def test_context_update_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.context_update(5)
+    assert "context_update expects 'ods.ContextVariables'" in str(exc.value)
+
+
+def test_password_update_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.password_update({})
+    assert "password_update expects 'ods.PasswordUpdate'" in str(exc.value)
+
+
+def test_file_access_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.file_access(())
+    assert "file_access expects 'ods.FileIdentifier'" in str(exc.value)
+
+
+def test_file_access_download_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.file_access_download((), "/tmp")
+    assert "file_access_download expects 'ods.FileIdentifier'" in str(exc.value)
+
+
+def test_file_access_upload_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.file_access_upload("not-file-id", "/tmp/nonexistent")
+    assert "file_access_upload expects 'ods.FileIdentifier'" in str(exc.value)
+
+
+def test_file_access_delete_type_error(dummy_con_i):
+    with pytest.raises(TypeError) as exc:
+        dummy_con_i.file_access_delete(123)
+    assert "file_access_delete expects 'ods.FileIdentifier'" in str(exc.value)


### PR DESCRIPTION
This pull request introduces type-checking for method arguments in the `ConI` class to ensure that the correct data types are passed, improving robustness and error handling. Additionally, it includes a comprehensive suite of negative type-check tests to validate these changes.

### Enhancements to error handling:

* [`src/odsbox/con_i.py`](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R236-R237): Added type-checking to various methods (`data_read`, `data_create`, `data_update`, `data_delete`, `data_copy`, etc.) to raise `TypeError` when arguments are of incorrect types. This ensures stricter adherence to expected data types for method parameters. [[1]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R236-R237) [[2]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R251-R252) [[3]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R266-R267) [[4]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R278-R279) [[5]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R290-R291) [[6]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R305-R308) [[7]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R322-R325) [[8]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R374-R375) [[9]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R404-R405) [[10]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R420-R421) [[11]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R455-R456) [[12]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R470-R471) [[13]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R504-R505) [[14]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R515-R516) [[15]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R529-R530) [[16]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R558-R561) [[17]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R609-R610) [[18]](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R638-R639)

### Test coverage improvements:

* [`tests/test_con_i_type_error.py`](diffhunk://#diff-2d411aa056d7387840c54bd8caeffb224ddba192beefc265365215c92d62970bR1-R123): Added negative type-check tests for all affected methods in the `ConI` class. These tests validate that a `TypeError` is raised when incorrect types are passed to the methods, ensuring the robustness of the type-checking logic.