### PR TITLE
fix: $null and $notnull have no value in a condition

### DIFF
--- a/src/odsbox/jaquel.py
+++ b/src/odsbox/jaquel.py
@@ -617,14 +617,18 @@ def __add_condition(
     condition_item.condition.attribute = attribute_name
     condition_item.condition.operator = __get_ods_operator(attribute_type, condition_operator, condition_options)
     condition_item.condition.unit_id = int(condition_unit_id)
-    __set_condition_value(
-        model,
-        attribute_entity,
-        attribute_name,
-        attribute_type,
-        condition_operand_value,
-        condition_item.condition,
-    )
+    if condition_item.condition.operator not in (
+        OperatorEnum.OP_IS_NULL,
+        OperatorEnum.OP_IS_NOT_NULL,
+    ):
+        __set_condition_value(
+            model,
+            attribute_entity,
+            attribute_name,
+            attribute_type,
+            condition_operand_value,
+            condition_item.condition,
+        )
 
 
 def __parse_conditions(

--- a/tests/test_data/jaquel/bugs/bug_127_$notnull.json
+++ b/tests/test_data/jaquel/bugs/bug_127_$notnull.json
@@ -1,0 +1,10 @@
+{
+    "AoMeasurement": {
+        "measurement_begin": {
+            "$notnull": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}

--- a/tests/test_data/jaquel/bugs/bug_127_$notnull.json.proto
+++ b/tests/test_data/jaquel/bugs/bug_127_$notnull.json.proto
@@ -1,0 +1,18 @@
+{
+    "columns": [
+        {
+            "aid": "79",
+            "attribute": "*"
+        }
+    ],
+    "where": [
+        {
+            "condition": {
+                "aid": "79",
+                "attribute": "MeasurementBegin",
+                "operator": "OP_IS_NOT_NULL"
+            }
+        }
+    ],
+    "rowLimit": "5"
+}

--- a/tests/test_data/jaquel/bugs/bug_127_$null.json
+++ b/tests/test_data/jaquel/bugs/bug_127_$null.json
@@ -1,0 +1,10 @@
+{
+    "AoMeasurement": {
+        "measurement_begin": {
+            "$null": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}

--- a/tests/test_data/jaquel/bugs/bug_127_$null.json.proto
+++ b/tests/test_data/jaquel/bugs/bug_127_$null.json.proto
@@ -1,0 +1,18 @@
+{
+    "columns": [
+        {
+            "aid": "79",
+            "attribute": "*"
+        }
+    ],
+    "where": [
+        {
+            "condition": {
+                "aid": "79",
+                "attribute": "MeasurementBegin",
+                "operator": "OP_IS_NULL"
+            }
+        }
+    ],
+    "rowLimit": "5"
+}


### PR DESCRIPTION
This pull request introduces support for `$null` and `$notnull` operators in the `jaquel` module, along with corresponding test cases and improvements to error reporting in test assertions. The changes enhance functionality and improve debugging capabilities.

### Feature Enhancements:

* **Support for `$null` and `$notnull` operators**:
  - Modified `__add_condition` in `src/odsbox/jaquel.py` to handle `$null` and `$notnull` operators by ensuring the condition value is only set for operators other than `OP_IS_NULL` and `OP_IS_NOT_NULL`.

### Test Additions:

* **New test cases for `$null` and `$notnull`**:
  - Added `bug_127_$notnull.json` and `bug_127_$notnull.json.proto` to test `$notnull` operator behavior. [[1]](diffhunk://#diff-85dc13f20cccd6540c7cf2149abe0bb55f24aa8aa25995ea1ea35efd15593d2bR1-R10) [[2]](diffhunk://#diff-04964bc7da1c4de661edd9b875a1474934657a022b60e7688f6d3fbef6563779R1-R18)
  - Added `bug_127_$null.json` and `bug_127_$null.json.proto` to test `$null` operator behavior. [[1]](diffhunk://#diff-118d25928bd50c6fc70550665c01d76525d1e72ce8620441aa7b37019e89a672R1-R10) [[2]](diffhunk://#diff-bc63971476b2bcfaf15c46ca2357b3b3ed2d3fc5e2cd9c8f30761e07487d7854R1-R18)
  - Implemented `test_issue_127_not_null` and `test_issue_127_null` in `tests/test_jaquel_convert.py` to validate `$null` and `$notnull` operators in integration tests.
