### PR TITLE
docs: add parameters to documentation of query_data

### DIFF
--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -191,6 +191,8 @@ class ConI:
     def query_data(
         self,
         query: str | dict | ods.SelectStatement,
+        enum_as_string: bool = False,
+        date_as_timestamp: bool = False,
         **kwargs,
     ) -> DataFrame:
         """
@@ -198,6 +200,11 @@ class ConI:
 
         :param str | dict | ods.SelectStatement query: Query given as JAQueL query (dict or str)
             or as an ASAM ODS SelectStatement.
+        :param bool enum_as_string: columns of type DT_ENUM or DS_ENUM are returned as int values.
+                                    If this is set to True the model_cache is used to map the int values
+                                    to the corresponding string values.
+        :param bool date_as_timestamp: columns of type DT_DATE or DS_DATE are returned as string.
+                                       If this is set to True the strings are converted to pandas Timestamp.
         :param kwargs: additional arguments passed to `to_pandas`.
         :raises requests.HTTPError: If query fails.
         :return DataFrame: The DataMatrices as Pandas.DataFrame. The columns are named as `ENTITY_NAME.ATTRIBUTE_NAME`.
@@ -206,7 +213,13 @@ class ConI:
         data_matrices = (
             self.data_read(query) if isinstance(query, ods.SelectStatement) else self.data_read_jaquel(query)
         )
-        return to_pandas(data_matrices, model_cache=self.mc, **kwargs)
+        return to_pandas(
+            data_matrices,
+            model_cache=self.mc,
+            enum_as_string=enum_as_string,
+            date_as_timestamp=date_as_timestamp,
+            **kwargs,
+        )
 
     def model(self) -> ods.Model:
         """


### PR DESCRIPTION
Add parameters to query_data to make them show up in auto complete and documentation.

### Enhancements to `query_data` method:

* Added two optional parameters, `enum_as_string` and `date_as_timestamp`, to the `query_data` method to provide more control over how data types are handled:
  - [`enum_as_string`](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R194-R207): Allows columns of type `DT_ENUM` or `DS_ENUM` to be returned as string values instead of integers, using the `model_cache` for mapping.
  - [`date_as_timestamp`](diffhunk://#diff-840a8b2b01d75cf56bff6517bb7d0999a8a4d3774259dae32fdb05457b22b422R194-R207): Converts columns of type `DT_DATE` or `DS_DATE` from string format to Pandas `Timestamp` objects.

* Updated the method implementation to pass the new parameters (`enum_as_string` and `date_as_timestamp`) to the `to_pandas` function, ensuring these options are applied during data conversion.