### PR TITLE
feat: add $nested aggregation to jaquel conditions

### DIFF
--- a/docs/jaquel.md
+++ b/docs/jaquel.md
@@ -485,6 +485,7 @@ r = con_i.query_data({
 | $point     | used for query on bulk data. returning indices of local column values |
 | $ia        | Retrieve an instance attribute |
 | $unit      | define the unit by its id that should be used for the return values |
+| $nested    | used to assign another jaquel query to an condition |
 
 | global options | description                                |
 |----------------|--------------------------------------------|

--- a/src/odsbox/__init__.py
+++ b/src/odsbox/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -375,3 +375,20 @@ def test_do_not_load_model():
         # Access the cached model
         assert con_i.mc is not None
         con_i.model()
+
+
+@pytest.mark.integration
+def test_nested_query(request: FixtureRequest):
+    with __create_con_i() as con_i:
+        df = con_i.query_data(
+            {"AoTest": {"name": {"$in": {"$nested": {"AoTest": {}, "$attributes": {"name": {"$distinct": 1}}}}}}}
+        )
+
+        assert df is not None
+        assert not df.empty
+
+        _, s = jaquel_to_ods(
+            con_i.model(),
+            {"AoTest": {"name": {"$in": {"$nested": {"AoTest": {}, "$attributes": {"name": {"$distinct": 1}}}}}}},
+        )
+        assert s.where[0].condition.nested_statement.columns[0].attribute is not None


### PR DESCRIPTION
This pull request introduces support for the new `$nested` operator in Jaquel queries, enabling nested subquery conditions. It updates the core parsing logic, documentation, and adds comprehensive unit and integration tests to ensure correct behavior and error handling. The changes also improve suggestion messages for unknown aggregates and increment the package version.

### Core Feature: Nested Query Support

* Added support for the `$nested` operator in Jaquel query conditions, allowing users to specify nested subqueries for condition values. This includes a new `_handle_nested_statement` function and logic in `_parse_conditions` to detect and process `$nested` constructs, with validation to prevent usage with `$null` or `$notnull` operators. [[1]](diffhunk://#diff-4755dc930d4ceb9f6aca5365d6f03649fc7ce3e94e983ceb8731eaaf4bc7dbcfR491-R529) [[2]](diffhunk://#diff-4755dc930d4ceb9f6aca5365d6f03649fc7ce3e94e983ceb8731eaaf4bc7dbcfR725-R747)

### Documentation

* Updated `docs/jaquel.md` to document the new `$nested` operator and its usage in query conditions.

### Testing

* Added extensive unit and integration tests for the `$nested` operator, covering basic usage, error cases (such as invalid operators), and various valid operators. This includes new tests in `tests/test_con_i.py`, `tests/test_jaquel_convert.py`, and `tests/test_jaquel_mocked.py`. [[1]](diffhunk://#diff-1db0b2d380777aee6760d6c7c38eeae1c7c3594d53eef01bd6bf3852d46125c7R378-R394) [[2]](diffhunk://#diff-c2768f4684bd7d827dc0556d98cd095af24437678229ed8237217c294d8e2ac7R334-R409) [[3]](diffhunk://#diff-a395320d7a4af2ea4003e9fe60caff955671f633dfa9ab259c3c2cf739813648R1479-R1654)

### Versioning

* Bumped the package version from `1.0.8` to `1.0.9` to reflect the new feature.