### PR TITLE
feat: simplify import

### DIFF
--- a/src/odsbox/__init__.py
+++ b/src/odsbox/__init__.py
@@ -1,5 +1,33 @@
-"""odsbox"""
+"""odsbox - Toolbox for accessing ASAM ODS servers using the HTTP API
+
+This package provides convenient access to ASAM ODS servers with lazy loading
+for better performance.
+
+Example:
+    from odsbox import ConI
+
+    with ConI(url="http://localhost:8087/api", auth=("sa", "sa")) as con_i:
+        units = con_i.query_data({"AoUnit": {}})
+"""
 
 from __future__ import annotations
 
-__version__ = "1.0.10"
+__version__ = "1.0.11"
+
+
+def __getattr__(name: str):
+    """Lazy import for better performance"""
+    if name == "ConI":
+        from .con_i import ConI
+
+        return ConI
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """Return list of available attributes for tab completion"""
+    return ["ConI", "__version__"]
+
+
+# Define what gets imported with "from odsbox import *"
+__all__ = ["ConI"]

--- a/src/odsbox/proto/__init__.py
+++ b/src/odsbox/proto/__init__.py
@@ -1,0 +1,55 @@
+"""ASAM ODS Protocol Buffer interfaces
+
+This module provides convenient access to ASAM ODS protobuf definitions
+with lazy loading for better performance.
+
+Example:
+    from odsbox.proto import ods, ods_security
+
+    # Create a model instance
+    model = ods.Model()
+"""
+
+from __future__ import annotations
+
+
+def __getattr__(name: str):
+    """Lazy import for better performance and optional dependencies"""
+    if name == "ods":
+        from . import ods_pb2 as ods
+
+        return ods
+    elif name == "ods_security":
+        from . import ods_security_pb2 as ods_security
+
+        return ods_security
+    elif name == "ods_notification":
+        from . import ods_notification_pb2 as ods_notification
+
+        return ods_notification
+    elif name == "ods_external_data":
+        try:
+            from . import ods_external_data_pb2 as ods_external_data
+
+            return ods_external_data
+        except ImportError as e:
+            raise ImportError("ods_external_data requires grpcio. Install with: pip install odsbox[exd-data]") from e
+    elif name == "ods_external_data_grpc":
+        try:
+            from . import ods_external_data_pb2_grpc as ods_external_data_grpc
+
+            return ods_external_data_grpc
+        except ImportError as e:
+            raise ImportError(
+                "ods_external_data_grpc requires grpcio. Install with: pip install odsbox[exd-data]"
+            ) from e
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """Return list of available attributes for tab completion"""
+    return ["ods", "ods_security", "ods_notification", "ods_external_data", "ods_external_data_grpc"]
+
+
+# Define what gets imported with "from odsbox.proto import *"
+__all__ = ["ods", "ods_security", "ods_notification", "ods_external_data", "ods_external_data_grpc"]

--- a/tests/test_odsbox_init.py
+++ b/tests/test_odsbox_init.py
@@ -1,0 +1,126 @@
+"""Tests for odsbox.__init__ lazy loading functionality"""
+
+import pytest
+import sys
+
+
+def test_odsbox_lazy_import_coni():
+    """Test that ConI is lazily imported"""
+    from odsbox import ConI
+
+    # Should be the actual ConI class
+    assert ConI.__name__ == "ConI"
+    assert hasattr(ConI, "__enter__")  # Context manager
+    assert hasattr(ConI, "__exit__")  # Context manager
+    assert hasattr(ConI, "query_data")
+
+
+def test_odsbox_getattr_invalid_attribute():
+    """Test that invalid attribute names raise AttributeError"""
+    import odsbox
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = odsbox.invalid_attribute
+
+    assert "has no attribute 'invalid_attribute'" in str(exc_info.value)
+
+
+def test_odsbox_dir_contains_expected_attributes():
+    """Test that __dir__ returns expected attribute names"""
+    import odsbox
+
+    dir_result = dir(odsbox)
+    expected_attributes = ["ConI", "__version__"]
+
+    for attribute in expected_attributes:
+        assert attribute in dir_result
+
+
+def test_odsbox_all_contains_expected_attributes():
+    """Test that __all__ contains expected attribute names"""
+    import odsbox
+
+    expected_attributes = ["ConI"]
+
+    assert odsbox.__all__ == expected_attributes
+
+
+def test_odsbox_version_attribute():
+    """Test that __version__ is accessible"""
+    import odsbox
+
+    assert hasattr(odsbox, "__version__")
+    assert isinstance(odsbox.__version__, str)
+    assert odsbox.__version__ == "1.0.11"
+
+
+def test_odsbox_lazy_loading_behavior():
+    """Test that modules are only loaded when accessed"""
+    import importlib
+    import odsbox
+
+    # Force reload to clear any caching
+    importlib.reload(odsbox)
+
+    # Remove relevant modules from cache
+    modules_to_remove = [key for key in sys.modules.keys() if key.startswith("odsbox.con_i")]
+    for mod in modules_to_remove:
+        del sys.modules[mod]
+
+    # Verify module is not loaded yet
+    assert "odsbox.con_i" not in sys.modules
+
+    # Access ConI - this should trigger the lazy import
+    _ = odsbox.ConI
+
+    # Now odsbox.con_i should be in sys.modules
+    assert "odsbox.con_i" in sys.modules
+
+
+def test_odsbox_module_caching():
+    """Test that modules are cached after first import"""
+    import odsbox
+
+    # Import ConI twice
+    coni1 = odsbox.ConI
+    coni2 = odsbox.ConI
+
+    # Should be the same class object (cached)
+    assert coni1 is coni2
+
+
+def test_odsbox_import_from_star():
+    """Test 'from odsbox import *' functionality"""
+    import odsbox
+
+    # Verify that accessing attributes in __all__ works
+    for attr_name in odsbox.__all__:
+        attr = getattr(odsbox, attr_name)
+        assert attr is not None
+
+
+def test_odsbox_backwards_compatibility():
+    """Test that old import style still works"""
+    # Old style imports should still work
+    from odsbox.con_i import ConI as ConI_old
+
+    # New style imports
+    from odsbox import ConI
+
+    # Should be the same object
+    assert ConI is ConI_old
+
+
+def test_odsbox_readme_example():
+    """Test that the README example works with the new API"""
+    from odsbox import ConI
+
+    # This should work without errors (just test the import and class access)
+    assert ConI is not None
+    assert hasattr(ConI, "__init__")
+
+    # We can't test the actual connection without a server,
+    # but we can verify the class has the expected interface
+    assert hasattr(ConI, "query_data")
+    assert hasattr(ConI, "__enter__")
+    assert hasattr(ConI, "__exit__")

--- a/tests/test_proto_init.py
+++ b/tests/test_proto_init.py
@@ -1,0 +1,166 @@
+"""Tests for odsbox.proto lazy loading functionality"""
+
+import pytest
+import sys
+
+
+def test_proto_lazy_import_ods():
+    """Test that ods module is lazily imported"""
+    # Remove from cache if already imported
+    if "odsbox.proto" in sys.modules:
+        del sys.modules["odsbox.proto"]
+
+    from odsbox.proto import ods
+
+    # Should be the actual ods_pb2 module
+    assert hasattr(ods, "Model")
+    assert hasattr(ods, "DataMatrices")
+    assert hasattr(ods, "SelectStatement")
+
+
+def test_proto_lazy_import_ods_security():
+    """Test that ods_security module is lazily imported"""
+    from odsbox.proto import ods_security
+
+    # Should be the actual ods_security_pb2 module
+    assert hasattr(ods_security, "SecurityInfo")
+    assert hasattr(ods_security, "SecurityEntry")
+
+
+def test_proto_lazy_import_ods_notification():
+    """Test that ods_notification module is lazily imported"""
+    from odsbox.proto import ods_notification
+
+    # Should be the actual ods_notification_pb2 module
+    assert hasattr(ods_notification, "Notification")
+
+
+def test_proto_lazy_import_multiple():
+    """Test importing multiple modules at once"""
+    from odsbox.proto import ods, ods_security, ods_notification
+
+    assert hasattr(ods, "Model")
+    assert hasattr(ods_security, "SecurityInfo")
+    assert hasattr(ods_notification, "Notification")
+
+
+def test_proto_getattr_invalid_module():
+    """Test that invalid module names raise AttributeError"""
+    import odsbox.proto as proto
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = proto.invalid_module
+
+    assert "has no attribute 'invalid_module'" in str(exc_info.value)
+
+
+def test_proto_dir_contains_expected_modules():
+    """Test that __dir__ returns expected module names"""
+    import odsbox.proto as proto
+
+    dir_result = dir(proto)
+    expected_modules = ["ods", "ods_security", "ods_notification", "ods_external_data", "ods_external_data_grpc"]
+
+    for module in expected_modules:
+        assert module in dir_result
+
+
+def test_proto_all_contains_expected_modules():
+    """Test that __all__ contains expected module names"""
+    import odsbox.proto as proto
+
+    expected_modules = ["ods", "ods_security", "ods_notification", "ods_external_data", "ods_external_data_grpc"]
+
+    assert proto.__all__ == expected_modules
+
+
+def test_proto_lazy_loading_behavior():
+    """Test that modules are only loaded when accessed"""
+    import importlib
+    import odsbox.proto as proto
+
+    # Force reload of the proto module to clear any caching
+    importlib.reload(proto)
+
+    # Remove from cache to ensure clean state
+    modules_to_remove = [key for key in sys.modules.keys() if key.startswith("odsbox.proto.ods")]
+    for mod in modules_to_remove:
+        del sys.modules[mod]
+
+    # Re-import after clearing cache
+    if "odsbox.proto" in sys.modules:
+        del sys.modules["odsbox.proto"]
+    import odsbox.proto as proto
+
+    # Verify module is not loaded yet
+    assert "odsbox.proto.ods_pb2" not in sys.modules
+
+    # Access ods - this should trigger the lazy import
+    _ = proto.ods
+
+    # Now odsbox.proto.ods_pb2 should be in sys.modules
+    assert "odsbox.proto.ods_pb2" in sys.modules
+
+
+def test_proto_external_data_import_error_handling():
+    """Test graceful handling of missing grpcio dependency"""
+    # Test this by actually trying to access the module
+    # If grpcio is not installed, it should raise the expected error
+    import odsbox.proto as proto
+
+    try:
+        _ = proto.ods_external_data
+        # If we get here, grpcio is installed, which is fine
+        # We can't easily test the error case without breaking the environment
+        assert True
+    except ImportError as e:
+        # Expected if grpcio is not installed
+        assert "requires grpcio" in str(e)
+        assert "pip install odsbox[exd-data]" in str(e)
+
+
+def test_proto_external_data_grpc_import_error_handling():
+    """Test graceful handling of missing grpcio dependency for grpc module"""
+    import odsbox.proto as proto
+
+    try:
+        _ = proto.ods_external_data_grpc
+        # If we get here, grpcio is installed, which is fine
+        assert True
+    except ImportError as e:
+        # Expected if grpcio is not installed
+        assert "requires grpcio" in str(e)
+        assert "pip install odsbox[exd-data]" in str(e)
+
+
+def test_proto_import_from_star():
+    """Test 'from odsbox.proto import *' functionality"""
+    # This test verifies that __all__ works correctly
+    # We can't easily test the actual star import in pytest, but we can verify __all__
+    import odsbox.proto as proto
+
+    # Verify that accessing attributes in __all__ works
+    for attr_name in proto.__all__:
+        if attr_name in ["ods_external_data", "ods_external_data_grpc"]:
+            # These might fail due to missing grpcio, so we handle them separately
+            try:
+                attr = getattr(proto, attr_name)
+                assert attr is not None
+            except ImportError:
+                # Expected if grpcio is not installed
+                pass
+        else:
+            attr = getattr(proto, attr_name)
+            assert attr is not None
+
+
+def test_proto_module_caching():
+    """Test that modules are cached after first import"""
+    import odsbox.proto as proto
+
+    # Import ods twice
+    ods1 = proto.ods
+    ods2 = proto.ods
+
+    # Should be the same object (cached)
+    assert ods1 is ods2


### PR DESCRIPTION
This pull request introduces lazy loading for both the main `odsbox` package and its `proto` submodule, improving import performance and reducing unnecessary dependencies. It also adds comprehensive tests to ensure correct lazy loading behavior, attribute access, and error handling for optional dependencies.

``` python
from odsbox import ConI
from odsbox.proto import ods, ods_security
```

**Lazy loading and API improvements:**

* Added lazy loading to `odsbox` by implementing `__getattr__`, `__dir__`, and `__all__`, so `ConI` is only imported when accessed, and updated the module docstring and version to 1.0.11.
* Introduced lazy loading to `odsbox.proto`, including conditional imports for optional dependencies (e.g., `grpcio`), and improved tab completion and star-import support with `__dir__` and `__all__`.

**Testing enhancements:**

* Added `tests/test_odsbox_init.py` with thorough tests covering lazy loading, attribute errors, module caching, star-imports, and backwards compatibility for `odsbox`.
* Added `tests/test_proto_init.py` to test lazy loading, error handling for missing optional dependencies, module caching, and star-imports in `odsbox.proto`.