### PR TITLE
docs: add jaquel documentation examples

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
 				"ms-python.flake8",
 				"ms-python.black-formatter",
 				"ms-vsliveshare.vsliveshare",
+				"ms-vscode.live-server",
 				"ryanluker.vscode-coverage-gutters",
 				"tamasfe.even-better-toml",
 				"streetsidesoftware.code-spell-checker",

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install odsbox[exd-data]
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions! See CONTRIBUTING.md for guidelines.
 
 ## License
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,3 +77,9 @@ templates_path = ["_templates"]
 # Napoleon settings
 napoleon_include_init_with_doc = True
 napoleon_include_private_with_doc = True
+
+# Autodoc settings
+autodoc_typehints = "description"
+
+# Suppress warnings for multiple targets (e.g., ConI available both as odsbox.ConI and odsbox.con_i.ConI)
+suppress_warnings = ["ref.python"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx_sitemap",
     "myst_parser",
+    "sphinx_design",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to ASAM ODSBox docs's documentation!
    overview
    odsbox
    jaquel
+   jaquel_examples
    repository_rules
 
 Indices and tables

--- a/docs/jaquel_examples.md
+++ b/docs/jaquel_examples.md
@@ -1,0 +1,3037 @@
+# JAQuel Query Examples
+
+This document contains examples of JAQuel queries and their corresponding ASAM ODS SelectStatement protobuf message serialized as JSON.
+
+
+## Access Instances
+
+
+### Basic access
+
+
+#### Add some of the related physical dimension
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Unit": {},
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension.name": 1,
+        "phys_dimension.length_exp": 1,
+        "phys_dimension.mass_exp": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "Name"
+    },
+    {
+      "aid": "47",
+      "attribute": "Length"
+    },
+    {
+      "aid": "47",
+      "attribute": "Mass"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Do access only few attributes
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Unit": {},
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Lets query for units with base entity name
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {}
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Lets query for units with entity name
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Unit": {}
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Retrieve all attributes using asterisk
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Unit": {},
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension.*": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "*"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Simplify attribute definition
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Unit": {},
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension": {
+            "name": 1,
+            "length_exp": 1,
+            "mass_exp": 1
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "Name"
+    },
+    {
+      "aid": "47",
+      "attribute": "Length"
+    },
+    {
+      "aid": "47",
+      "attribute": "Mass"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+### Order results by an attribute
+
+
+#### Order results by  name
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$attributes": {
+        "id": 1,
+        "name": 1
+    },
+    "$orderby": {
+        "name": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Id"
+    },
+    {
+      "aid": "54",
+      "attribute": "Name"
+    }
+  ],
+  "orderBy": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    }
+  ]
+}
+```
+
+````
+
+
+### Limit the amounts of results
+
+
+#### Retrieve only 5 result rows
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Query Instance by  id
+
+
+#### Query the unit with the id 3
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "id": 3
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "3"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the id 3 full
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "id": {
+            "$eq": 3
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "3"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the id 3 simplified
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": 3
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "3"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the units with the ids in 1 , 2 and 3
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "id": {
+            "$in": [
+                1,
+                2,
+                3
+            ]
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Id",
+        "operator": "OP_INSET",
+        "longlongArray": {
+          "values": [
+            "1",
+            "2",
+            "3"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+### Query Instance by  name
+
+
+#### Query the unit with the name equal  s
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "name": "s"
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Name",
+        "stringArray": {
+          "values": [
+            "s"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the name equal  s  case insensitive
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "name": "s",
+        "$options": "i"
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Name",
+        "operator": "OP_CI_EQ",
+        "stringArray": {
+          "values": [
+            "s"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the name equal  s  case insensitive full
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "name": {
+            "$eq": "s"
+        },
+        "$options": "i"
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Name",
+        "operator": "OP_CI_EQ",
+        "stringArray": {
+          "values": [
+            "s"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the name like  k
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "name": {
+            "$like": "k*"
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Name",
+        "operator": "OP_LIKE",
+        "stringArray": {
+          "values": [
+            "k*"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+#### Query the unit with the name like  k   case insensitive
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "name": {
+            "$like": "k*"
+        },
+        "$options": "i"
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "54",
+        "attribute": "Name",
+        "operator": "OP_CI_LIKE",
+        "stringArray": {
+          "values": [
+            "k*"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+````
+
+
+### And conjunctions  $and  and  $or
+
+
+#### Search speed based Units
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "phys_dimension": {
+            "length_exp": 1,
+            "mass_exp": 0,
+            "time_exp": -1,
+            "current_exp": 0,
+            "temperature_exp": 0,
+            "molar_amount_exp": 0,
+            "luminous_intensity_exp": 0
+        }
+    },
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension.name": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "Name"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Length",
+        "longArray": {
+          "values": [
+            1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Mass",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Time",
+        "longArray": {
+          "values": [
+            -1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Current",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Temperature",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "MolarAmount",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "LuminousIntensity",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Search speed based Units with explicit  $and  conjunction
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "phys_dimension": {
+            "$and": [
+                {
+                    "length_exp": 1
+                },
+                {
+                    "mass_exp": 0
+                },
+                {
+                    "time_exp": -1
+                },
+                {
+                    "current_exp": 0
+                },
+                {
+                    "temperature_exp": 0
+                },
+                {
+                    "molar_amount_exp": 0
+                },
+                {
+                    "luminous_intensity_exp": 0
+                }
+            ]
+        }
+    },
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension.name": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "Name"
+    }
+  ],
+  "where": [
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Length",
+        "longArray": {
+          "values": [
+            1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Mass",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Time",
+        "longArray": {
+          "values": [
+            -1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Current",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Temperature",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "MolarAmount",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "LuminousIntensity",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Search speed or time based Units
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "phys_dimension": {
+            "$or": [
+                {
+                    "length_exp": 1,
+                    "mass_exp": 0,
+                    "time_exp": -1,
+                    "current_exp": 0,
+                    "temperature_exp": 0,
+                    "molar_amount_exp": 0,
+                    "luminous_intensity_exp": 0
+                },
+                {
+                    "length_exp": 0,
+                    "mass_exp": 0,
+                    "time_exp": 1,
+                    "current_exp": 0,
+                    "temperature_exp": 0,
+                    "molar_amount_exp": 0,
+                    "luminous_intensity_exp": 0
+                }
+            ]
+        }
+    },
+    "$attributes": {
+        "name": 1,
+        "factor": 1,
+        "offset": 1,
+        "phys_dimension.name": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset"
+    },
+    {
+      "aid": "47",
+      "attribute": "Name"
+    }
+  ],
+  "where": [
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Length",
+        "longArray": {
+          "values": [
+            1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Mass",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Time",
+        "longArray": {
+          "values": [
+            -1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Current",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Temperature",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "MolarAmount",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "LuminousIntensity",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_OR"
+    },
+    {
+      "conjunction": "CO_OPEN"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Length",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Mass",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Time",
+        "longArray": {
+          "values": [
+            1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Current",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Temperature",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "MolarAmount",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "LuminousIntensity",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    },
+    {
+      "conjunction": "CO_CLOSE"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Search time based Units
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {
+        "phys_dimension": {
+            "length_exp": 0,
+            "mass_exp": 0,
+            "time_exp": 1,
+            "current_exp": 0,
+            "temperature_exp": 0,
+            "molar_amount_exp": 0,
+            "luminous_intensity_exp": 0
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Length",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Mass",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Time",
+        "longArray": {
+          "values": [
+            1
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Current",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "Temperature",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "MolarAmount",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "conjunction": "CO_AND"
+    },
+    {
+      "condition": {
+        "aid": "47",
+        "attribute": "LuminousIntensity",
+        "longArray": {
+          "values": [
+            0
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "54",
+      "aidTo": "47",
+      "relation": "PhysDimension"
+    }
+  ]
+}
+```
+
+````
+
+
+### Use  $between  operator
+
+
+#### Get measurements that started in a time interval
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurement": {
+        "measurement_begin": {
+            "$between": [
+                "2000-04-22T00:00:00.001Z",
+                "2024-04-23T00:00:00.002Z"
+            ]
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "79",
+        "attribute": "MeasurementBegin",
+        "operator": "OP_BETWEEN",
+        "stringArray": {
+          "values": [
+            "20000422000000001",
+            "20240423000000002"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get measurements that started in a time interval, ODS time
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurement": {
+        "measurement_begin": {
+            "$between": [
+                "20001223000000",
+                "20241224000000"
+            ]
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "*"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "79",
+        "attribute": "MeasurementBegin",
+        "operator": "OP_BETWEEN",
+        "stringArray": {
+          "values": [
+            "20001223000000",
+            "20241224000000"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Use aggregates  $min ,  $max ,  $dcount , and  $distinct
+
+
+#### Get the distincted count of Unit description
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$attributes": {
+        "description": {
+            "$dcount": 1
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Description",
+      "aggregate": "AG_DCOUNT"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Get the distincted values of Unit description
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$attributes": {
+        "description": {
+            "$distinct": 1
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Description",
+      "aggregate": "AG_DISTINCT"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Get the min and max of unit factor
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$attributes": {
+        "factor": {
+            "$max": 1,
+            "$min": 1
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Factor",
+      "aggregate": "AG_MAX"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor",
+      "aggregate": "AG_MIN"
+    }
+  ]
+}
+```
+
+````
+
+
+#### Get the min and max of unit factor and offset
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoUnit": {},
+    "$attributes": {
+        "factor": {
+            "$max": 1,
+            "$min": 1
+        },
+        "offset": {
+            "$max": 1,
+            "$min": 1
+        }
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "54",
+      "attribute": "Factor",
+      "aggregate": "AG_MAX"
+    },
+    {
+      "aid": "54",
+      "attribute": "Factor",
+      "aggregate": "AG_MIN"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset",
+      "aggregate": "AG_MAX"
+    },
+    {
+      "aid": "54",
+      "attribute": "Offset",
+      "aggregate": "AG_MIN"
+    }
+  ]
+}
+```
+
+````
+
+
+### Inner and outer joins
+
+
+#### Use inner join
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurementQuantity": {},
+    "$attributes": {
+        "name": 1,
+        "unit.name": 1,
+        "quantity.name": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "80",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "55",
+      "attribute": "Name"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "80",
+      "aidTo": "54",
+      "relation": "Unit"
+    },
+    {
+      "aidFrom": "80",
+      "aidTo": "55",
+      "relation": "Quantity"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Use outer join
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurementQuantity": {},
+    "$attributes": {
+        "name": 1,
+        "unit:OUTER.name": 1,
+        "quantity:OUTER.name": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "80",
+      "attribute": "Name"
+    },
+    {
+      "aid": "54",
+      "attribute": "Name"
+    },
+    {
+      "aid": "55",
+      "attribute": "Name"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "80",
+      "aidTo": "54",
+      "relation": "Unit",
+      "joinType": "JT_OUTER"
+    },
+    {
+      "aidFrom": "80",
+      "aidTo": "55",
+      "relation": "Quantity",
+      "joinType": "JT_OUTER"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Use  $groupby
+
+
+#### Use a  $groupby  on two attributes
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurement": {},
+    "$attributes": {
+        "name": 1,
+        "description": 1
+    },
+    "$orderby": {
+        "name": 1
+    },
+    "$groupby": {
+        "name": 1,
+        "description": 1
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "Name"
+    },
+    {
+      "aid": "79",
+      "attribute": "Description"
+    }
+  ],
+  "orderBy": [
+    {
+      "aid": "79",
+      "attribute": "Name"
+    }
+  ],
+  "groupBy": [
+    {
+      "aid": "79",
+      "attribute": "Name"
+    },
+    {
+      "aid": "79",
+      "attribute": "Description"
+    }
+  ]
+}
+```
+
+````
+
+
+## Access OpenMDM content
+
+
+### Access hierarchy elements
+
+
+#### Get  AoTest  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoTest": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "48",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  MeaQuantity  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "MeaResult": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  MeaResult  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "MeaResult": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  Project  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Project": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "48",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  StructureLevel  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "StructureLevel": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "67",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  Test  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Test": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "77",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  TestStep  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "TestStep": {},
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "78",
+      "attribute": "*"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Browse ODS tree
+
+
+#### Get  MeaResult  from  TestStep  with  id  equal 4
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "TestStep": 4,
+    "$attributes": {
+        "children": {
+            "name": 1,
+            "id": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "Name"
+    },
+    {
+      "aid": "79",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "78",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "4"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "79",
+      "aidTo": "78",
+      "relation": "TestStep"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  MeaResult  with  test  with  id  equal 4
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "MeaResult": {
+        "test": 4
+    },
+    "$attributes": {
+        "name": 1,
+        "id": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "Name"
+    },
+    {
+      "aid": "79",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "79",
+        "attribute": "TestStep",
+        "longlongArray": {
+          "values": [
+            "4"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  StructureLevel  from  Project  with  id  equal 3
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "Project": 3,
+    "$attributes": {
+        "children": {
+            "name": 1,
+            "id": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "67",
+      "attribute": "Name"
+    },
+    {
+      "aid": "67",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "48",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "3"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "67",
+      "aidTo": "48",
+      "relation": "Project"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  StructureLevel  with  parent_test  with  id  equal 3
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "StructureLevel": {
+        "parent_test": 3
+    },
+    "$attributes": {
+        "name": 1,
+        "id": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "67",
+      "attribute": "Name"
+    },
+    {
+      "aid": "67",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "67",
+        "attribute": "Project",
+        "longlongArray": {
+          "values": [
+            "3"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Access descriptive meta
+
+
+#### Get some meta of related  AoUnitUnderTestPart  instances
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "MeaResult": {},
+    "$attributes": {
+        "id": 1,
+        "name": 1,
+        "units_under_test": {
+            "id": 1,
+            "vehicle.model": 1,
+            "engine.type": 1,
+            "gearbox.transmission": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "79",
+      "attribute": "Id"
+    },
+    {
+      "aid": "79",
+      "attribute": "Name"
+    },
+    {
+      "aid": "56",
+      "attribute": "Id"
+    },
+    {
+      "aid": "95",
+      "attribute": "model"
+    },
+    {
+      "aid": "88",
+      "attribute": "type"
+    },
+    {
+      "aid": "91",
+      "attribute": "transmission"
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "79",
+      "aidTo": "56",
+      "relation": "UnitUnderTest"
+    },
+    {
+      "aidFrom": "95",
+      "aidTo": "56",
+      "relation": "UnitUnderTest"
+    },
+    {
+      "aidFrom": "88",
+      "aidTo": "56",
+      "relation": "UnitUnderTest"
+    },
+    {
+      "aidFrom": "91",
+      "aidTo": "56",
+      "relation": "UnitUnderTest"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+### Access parameter sets
+
+
+#### Get name value pairs attached to  MeaResult
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "ResultParameter": {
+        "parameter_set.MeaResult.Name": {
+            "$like": "APS*"
+        }
+    },
+    "$attributes": {
+        "Name": 1,
+        "Value": 1,
+        "DataType": 1,
+        "parameter_set": {
+            "name": 1,
+            "MeaResult.id": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 20
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "66",
+      "attribute": "Name"
+    },
+    {
+      "aid": "66",
+      "attribute": "Value"
+    },
+    {
+      "aid": "66",
+      "attribute": "DataType"
+    },
+    {
+      "aid": "49",
+      "attribute": "Name"
+    },
+    {
+      "aid": "79",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "79",
+        "attribute": "Name",
+        "operator": "OP_LIKE",
+        "stringArray": {
+          "values": [
+            "APS*"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "66",
+      "aidTo": "49",
+      "relation": "ResultParameterSet"
+    },
+    {
+      "aidFrom": "49",
+      "aidTo": "79",
+      "relation": "MeaResult"
+    }
+  ],
+  "rowLimit": "20"
+}
+```
+
+````
+
+
+## Access Bulk
+
+
+### Read data from Measurement
+
+
+#### Get  AoMeasurementQuantity  from  AoMeasurement  with  id  equal 153
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurement": 153,
+    "$attributes": {
+        "measurement_quantities": {
+            "name": 1,
+            "id": 1
+        }
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "80",
+      "attribute": "Name"
+    },
+    {
+      "aid": "80",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "79",
+        "attribute": "Id",
+        "longlongArray": {
+          "values": [
+            "153"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "80",
+      "aidTo": "79",
+      "relation": "MeaResult"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  AoMeasurementQuantity  with  measurement  with  id  equal 153
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoMeasurementQuantity": {
+        "measurement": 153
+    },
+    "$attributes": {
+        "name": 1,
+        "id": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "80",
+      "attribute": "Name"
+    },
+    {
+      "aid": "80",
+      "attribute": "Id"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "80",
+        "attribute": "MeaResult",
+        "longlongArray": {
+          "values": [
+            "153"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get  AoSubmatrix  with  measurement  with  id  equal 153
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoSubmatrix": {
+        "measurement": 153
+    },
+    "$attributes": {
+        "name": 1,
+        "id": 1,
+        "number_of_rows": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "81",
+      "attribute": "Name"
+    },
+    {
+      "aid": "81",
+      "attribute": "Id"
+    },
+    {
+      "aid": "81",
+      "attribute": "SubMatrixNoRows"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "81",
+        "attribute": "MeaResult",
+        "longlongArray": {
+          "values": [
+            "153"
+          ]
+        }
+      }
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get bulk of  AoLocalColumn  with  submatrix.measurement  with  id  equal 153
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoLocalColumn": {
+        "submatrix.measurement": 153
+    },
+    "$attributes": {
+        "id": 1,
+        "flags": 1,
+        "generation_parameters": 1,
+        "values": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "82",
+      "attribute": "Id"
+    },
+    {
+      "aid": "82",
+      "attribute": "Flags"
+    },
+    {
+      "aid": "82",
+      "attribute": "GenerationParameters"
+    },
+    {
+      "aid": "82",
+      "attribute": "Values"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "81",
+        "attribute": "MeaResult",
+        "longlongArray": {
+          "values": [
+            "153"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "82",
+      "aidTo": "81",
+      "relation": "SubMatrix"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+
+
+#### Get meta of  AoLocalColumn  with  submatrix.measurement  with  id  equal 153
+
+````{tab-set}
+
+```{tab-item} JAQuel Query
+
+```json
+{
+    "AoLocalColumn": {
+        "submatrix.measurement": 153
+    },
+    "$attributes": {
+        "name": 1,
+        "id": 1,
+        "sequence_representation": 1,
+        "independent": 1,
+        "global_flag": 1
+    },
+    "$options": {
+        "$rowlimit": 5
+    }
+}
+```
+
+```{tab-item} ODS SelectStatement
+
+```json
+{
+  "columns": [
+    {
+      "aid": "82",
+      "attribute": "Name"
+    },
+    {
+      "aid": "82",
+      "attribute": "Id"
+    },
+    {
+      "aid": "82",
+      "attribute": "SequenceRepresentation"
+    },
+    {
+      "aid": "82",
+      "attribute": "IndependentFlag"
+    },
+    {
+      "aid": "82",
+      "attribute": "GlobalFlag"
+    }
+  ],
+  "where": [
+    {
+      "condition": {
+        "aid": "81",
+        "attribute": "MeaResult",
+        "longlongArray": {
+          "values": [
+            "153"
+          ]
+        }
+      }
+    }
+  ],
+  "joins": [
+    {
+      "aidFrom": "82",
+      "aidTo": "81",
+      "relation": "SubMatrix"
+    }
+  ],
+  "rowLimit": "5"
+}
+```
+
+````
+

--- a/docs/odsbox.rst
+++ b/docs/odsbox.rst
@@ -70,7 +70,7 @@ security
    :show-inheritance:
 
 bulk_reader
----------
+-----------
 
 .. automodule:: odsbox.bulk_reader
    :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx-copybutton
+sphinx-design
 sphinx-rtd-theme
 sphinx-sitemap
 myst_parser

--- a/tests/test_data/jaquel/generate_jaquel_docs.py
+++ b/tests/test_data/jaquel/generate_jaquel_docs.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Generate markdown documentation from JAQuel test files
+"""
+
+import re
+from pathlib import Path
+
+
+def parse_filename(filename):
+    """Parse filename to extract numbers and text parts"""
+    # Remove file extensions
+    name = filename.replace(".json.proto", "").replace(".json", "")
+
+    # Split by numbers to get parts
+    parts = re.split(r"(\d+)", name)
+
+    # Filter out empty parts and create structure
+    filtered_parts = [p.strip() for p in parts if p.strip()]
+
+    return filtered_parts
+
+
+def organize_files():
+    """Organize files by their hierarchical structure"""
+    # Get the directory where this script is located
+    script_dir = Path(__file__).parent
+    jaquel_dir = script_dir  # The script is already in the jaquel directory
+    files = {}
+
+    for file in jaquel_dir.glob("*.json"):
+        if file.name.endswith(".json.proto"):
+            continue
+
+        parts = parse_filename(file.name)
+        if len(parts) >= 6:  # Ensure we have enough parts
+            # Extract main numbers and headings
+            main_num = parts[0]
+            main_heading = parts[1]
+            sub_num = parts[2]
+            sub_heading = parts[3]
+            detail_num = parts[4]
+            detail_text = " ".join(parts[5:])  # Rest as detail
+
+            key = (main_num, main_heading, sub_num, sub_heading, detail_num, detail_text)
+
+            # Read both JSON and proto files
+            json_file = file
+            proto_file = jaquel_dir / f"{file.name}.proto"
+
+            json_content = ""
+            proto_content = ""
+
+            if json_file.exists():
+                with open(json_file, "r") as f:
+                    json_content = f.read()
+
+            if proto_file.exists():
+                with open(proto_file, "r") as f:
+                    proto_content = f.read()
+
+            files[key] = {"json": json_content, "proto": proto_content}
+
+    return files
+
+
+def generate_markdown():
+    """Generate the markdown documentation"""
+    files = organize_files()
+
+    # Sort files by their keys
+    sorted_files = sorted(files.items())
+
+    markdown = "# JAQuel Query Examples\n\n"
+    markdown += "This document contains examples of JAQuel queries and their corresponding "
+    markdown += "ASAM ODS SelectStatement protobuf message serialized as JSON.\n\n"
+
+    current_main = None
+    current_sub = None
+
+    for key, content in sorted_files:
+        main_num, main_heading, sub_num, sub_heading, detail_num, detail_text = key
+
+        # Main heading
+        if current_main != (main_num, main_heading):
+            markdown += f"\n## {main_heading}\n\n"
+            current_main = (main_num, main_heading)
+            current_sub = None
+
+        # Sub heading
+        if current_sub != (sub_num, sub_heading):
+            markdown += f"\n### {sub_heading}\n\n"
+            current_sub = (sub_num, sub_heading)
+
+        # Detail section
+        markdown += f"\n#### {detail_text}\n\n"
+
+        # Code block with tabs
+        markdown += "````{tab-set}\n\n"
+
+        # JAQuel Query tab
+        markdown += "```{tab-item} JAQuel Query\n\n"
+        markdown += "```json\n"
+        markdown += content["json"]
+        markdown += "\n```\n\n"
+
+        # Protocol Buffer Response tab
+        markdown += "```{tab-item} ODS SelectStatement\n\n"
+        markdown += "```json\n"
+        markdown += content["proto"]
+        markdown += "\n```\n\n"
+
+        markdown += "````\n\n"
+
+    return markdown
+
+
+if __name__ == "__main__":
+    markdown_content = generate_markdown()
+
+    # Get the script directory and navigate to docs directory
+    script_dir = Path(__file__).parent
+    # Navigate up from tests/test_data/jaquel to project root, then to docs
+    docs_dir = script_dir.parent.parent.parent / "docs"
+    output_file = docs_dir.resolve() / "jaquel_examples.md"
+
+    with open(output_file, "w") as f:
+        f.write(markdown_content)
+
+    print(f"Generated {output_file}")
+    print(f"Total length: {len(markdown_content)} characters")


### PR DESCRIPTION
This pull request introduces several documentation improvements and developer experience enhancements, with a focus on expanding and organizing JAQuel query examples, improving Sphinx documentation configuration, and updating development dependencies.

**Documentation enhancements:**

* Added a script `generate_jaquel_docs.py` to automatically generate markdown documentation from JAQuel test files, organizing examples and their protobuf responses into a structured, tabbed format for inclusion in the docs.
* Included a new `jaquel_examples` section in the documentation index, making JAQuel query examples easily accessible to users.
* Minor formatting fix in the `odsbox.rst` documentation for improved readability.

**Sphinx and docs configuration:**

* Added `sphinx_design` to the documentation requirements and enabled it in `conf.py`, allowing for advanced UI elements (such as tabbed code blocks) in the documentation. [[1]](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90R3) [[2]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R45)
* Updated Sphinx configuration to improve type hint rendering, suppress duplicate reference warnings, and enhance autodoc output.

**Developer experience:**

* Added the `ms-vscode.live-server` extension to the devcontainer configuration to support live preview of documentation and web content during development.

**Other minor improvements:**

* Fixed a markdown link formatting issue in the `README.md` to ensure the CONTRIBUTING guidelines are referenced correctly.