### PR TITLE
fix: added missing pandoc

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,5 +14,7 @@ jobs:
       pages: write
       id-token: write
     steps:
+    - name: Install Pandoc
+      run: sudo apt-get update && sudo apt-get install -y pandoc
     - id: deployment
       uses: sphinx-notes/pages@3.4


### PR DESCRIPTION
This pull request adds a step to the Sphinx documentation deployment workflow to install Pandoc before running the deployment. This ensures that Pandoc is available for any documentation builds that require it. 

* Workflow improvement:
  * [`.github/workflows/sphinx.yml`](diffhunk://#diff-3b5400f13c20505910b5f51111b34c0c17ad7137e82e2859cef6ee5a09e77f8dR17-R18): Added a step to install Pandoc using `apt-get` before the deployment step.