### PR TITLE
feat: add raw rational to bulk reader

### DIFF
--- a/src/odsbox/bulk_reader.py
+++ b/src/odsbox/bulk_reader.py
@@ -35,6 +35,8 @@ class SeqRepEnum(IntEnum):
     raw_polynomial_external = 9
     raw_linear_calibrated = 10
     raw_linear_calibrated_external = 11
+    raw_rational = 12
+    raw_rational_external = 13
     # pylint: enable=C0103
 
 
@@ -145,6 +147,25 @@ class BulkReader:
                         p3 = generation_parameters[2]
                         double_vals = np.array(vals, dtype=float)
                         localcolumn_df.at[index, "values"] = (p1 + p2 * double_vals) * p3
+                    else:
+                        raise ValueError(f"Generation parameters missing for {name}")
+            elif sequence_representation in [
+                SeqRepEnum.raw_rational,
+                SeqRepEnum.raw_rational_external,
+            ]:
+                if calculate_raw:
+                    generation_parameters = r.get("generation_parameters")
+                    if isinstance(generation_parameters, (list, tuple)) and len(generation_parameters) >= 3:
+                        p1 = generation_parameters[0]
+                        p2 = generation_parameters[1]
+                        p3 = generation_parameters[2]
+                        p4 = generation_parameters[3]
+                        p5 = generation_parameters[4]
+                        p6 = generation_parameters[5]
+                        double_vals = np.array(vals, dtype=float)
+                        localcolumn_df.at[index, "values"] = (p1 * double_vals**2 + p2 * double_vals + p3) / (
+                            p4 * double_vals**2 + p5 * double_vals + p6
+                        )
                     else:
                         raise ValueError(f"Generation parameters missing for {name}")
             else:

--- a/tests/test_bulk_reader.py
+++ b/tests/test_bulk_reader.py
@@ -76,6 +76,13 @@ def test_apply_sequence_representation_various():
                 "generation_parameters": [1.0, 2.0, 3.0],
                 "number_of_rows": 2,
             },
+            {
+                "name": "rational",
+                "values": [1, 2],
+                "sequence_representation": SeqRepEnum.raw_rational.value,
+                "generation_parameters": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                "number_of_rows": 2,
+            },
         ]
     )
 
@@ -96,6 +103,12 @@ def test_apply_sequence_representation_various():
 
     # calibrated: (p1 + p2 * vals) * p3
     assert list(df.loc[4, "values"]) == [(1.0 + 2.0 * 1.0) * 3.0, (1.0 + 2.0 * 2.0) * 3.0]
+
+    # rational: (p1 * vals^2  + p2 * vals + p3) / (p4 * vals^2 + p5 * vals + p6)
+    assert list(df.loc[5, "values"]) == [
+        (1.0 * 1.0**2 + 2.0 * 1.0 + 3.0) / (4.0 * 1.0**2 + 5.0 * 1.0 + 6.0),
+        (1.0 * 2.0**2 + 2.0 * 2.0 + 3.0) / (4.0 * 2.0**2 + 5.0 * 2.0 + 6.0),
+    ]
 
 
 def test_apply_sequence_representation_errors():


### PR DESCRIPTION
This pull request adds support for a new "rational" sequence representation in the bulk data reader, allowing values to be generated using a rational function. The update includes changes to the core logic, the enumeration of sequence representations, and the test suite to ensure proper handling and correctness of the new type.

**Support for rational sequence representation:**

* Added two new sequence representation types, `raw_rational` and `raw_rational_external`, to the `SeqRepEnum` in `bulk_reader.py`.
* Updated the `__apply_sequence_representation` function to handle the new rational types, computing values using a rational function of the form `(p1 * x^2 + p2 * x + p3) / (p4 * x^2 + p5 * x + p6)`.

**Testing enhancements:**

* Added a new test case in `test_apply_sequence_representation_various` to cover the rational sequence representation, including appropriate generation parameters.
* Added assertions in the test suite to verify that the rational function is applied correctly to the input values.