### PR TITLE
fix: 184 conidata read jaquel api broken because querywas renamed to jaquel query

### DIFF
--- a/src/odsbox/__init__.py
+++ b/src/odsbox/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 
 if TYPE_CHECKING:
     from .con_i import ConI

--- a/src/odsbox/con_i.py
+++ b/src/odsbox/con_i.py
@@ -354,16 +354,16 @@ class ConI:
         """
         return self.mc.model()
 
-    def data_read_jaquel(self, jaquel_query: str | dict) -> ods.DataMatrices:
+    def data_read_jaquel(self, query: str | dict) -> ods.DataMatrices:
         """
         Query ods server for content.
 
-        :param str | dict  jaquel_query: Query given as JAQueL query (dict or str).
+        :param str | dict  query: Query given as JAQueL query (dict or str).
         :raises requests.HTTPError: If query fails.
         :return ods.DataMatrices: The DataMatrices representing the result.
             It will contain one ods.DataMatrix for each returned entity type.
         """
-        jaquel = Jaquel(self.model(), jaquel_query)
+        jaquel = Jaquel(self.model(), query)
         return self.data_read(jaquel.select_statement)
 
     def data_read(self, select_statement: ods.SelectStatement) -> ods.DataMatrices:

--- a/tests/test_con_i.py
+++ b/tests/test_con_i.py
@@ -166,7 +166,7 @@ def test_values_data_read(request: FixtureRequest):
         assert lc_info_df.empty is False
 
         lc_info_dms = con_i.data_read_jaquel(
-            {
+            query={
                 "AoLocalColumn": {"submatrix": sm_id},
                 "$attributes": {"id": 1, "name": 1, "sequence_representation": 1, "independent": 1},
             }
@@ -187,7 +187,7 @@ def test_values_data_read(request: FixtureRequest):
         assert lc_values_df.empty is False
 
         lc_values_dms = con_i.data_read_jaquel(
-            {
+            query={
                 "AoLocalColumn": {"submatrix": sm_id},
                 "$attributes": {"id": 1, "values": 1, "generation_parameters": 1},
                 "$options": {"$seqlimit": sm_number_of_rows, "$seqskip": 0},
@@ -205,7 +205,7 @@ def test_values_valuematrix_read_calculated(request: FixtureRequest):
     test_name = request.node.name
     with __create_con_i() as con_i:
         sm_df = con_i.query_data(
-            {
+            query={
                 "AoSubmatrix": {"name": "Profile_02"},
                 "$attributes": {"id": 1, "number_of_rows": 1},
                 "$options": {"$rowlimit": 1},
@@ -688,7 +688,7 @@ def test_query_with_kwargs():
         assert "name" in r.columns
 
         r = con_i.query(
-            {"AoUnit": {}, "$attributes": {"name": 1}, "$options": {"$rowlimit": 1}},
+            jaquel_query={"AoUnit": {}, "$attributes": {"name": 1}, "$options": {"$rowlimit": 1}},
             result_naming_mode="model",
             name_separator="::",
         )


### PR DESCRIPTION
ConI.data_read_jaquel API broken has been broken with 1.0.13..

```
def data_read_jaquel(self, query: str | dict) -> ods.DataMatrices:
```

changed to

```
def data_read_jaquel(self, jaquel_query: str | dict) -> ods.DataMatrices:
```

this breaks code like:

```
df = con_.data_read_jaquel(query={"AoUnit":{}})
```

This merge request is reverting this and closing issue #184 