### PR TITLE
feat: Add support for localcolumn flags in BulkReader

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,7 @@
         "NOTINSET",
         "NOTLIKE",
         "notnull",
+        "nullable",
         "odsbox",
         "Oneof",
         "preconfigured",
@@ -71,5 +72,6 @@
         "TESTSTEP",
         "valuematrix",
         "webfinger"
-    ]
+    ],
+    "chat.disableAIFeatures": false
 }

--- a/docs/con_read_bulk.md
+++ b/docs/con_read_bulk.md
@@ -1,0 +1,127 @@
+# Reading Bulk Data with `BulkReader`
+
+ASAM ODS stores measured/calculated values ("timeseries", "bulk data") in `AoLocalColumn`
+instances that belong to an `AoSubMatrix`. The raw ASAM ODS HTTP API models
+this in a way that is efficient over the wire but inconvenient to consume
+directly:
+
+* A local column's values are not always stored explicitly. They can be
+  described indirectly through a *sequence representation* (constant,
+  linear, raw-linear with calibration factors, rational, ...) plus a small
+  set of *generation parameters*, and the actual values have to be derived
+  from those parameters.
+* Values, units, and quality flags live in separate attributes/entities that
+  need to be queried and joined together.
+* The wire format is protobuf (`DataMatrices` / value matrices), not
+  something you want to work with directly in an analysis script.
+* The submatrix bundles local columns that have the same number of values and
+  the same independent column (e.g. "Time"), but you may want to read only a
+  subset of them.
+
+`BulkReader` exists to hide all of that and hand you a plain
+`pandas.DataFrame` instead. You don't use it directly — every `ConI` session
+exposes a ready-to-use instance via the `bulk` property:
+
+```python
+from odsbox.con_i import ConI
+
+with ConI(url="https://MYSERVER/api", auth=("USER", "PASSWORD")) as con_i:
+    df = con_i.bulk.data_read(submatrix_id, ["Time", "Co*"])
+```
+
+## Which method should I use?
+
+| Method                | Returns                                            | Values calculated by | Typical use case |
+| --------------------- | --------------------------------------------------- | --------------------- | ----------------- |
+| `data_read()`          | One column per local column, named by column name   | ODSBox (client)        | Default choice for reading a single submatrix |
+| `valuematrix_read()`   | Same shape as `data_read()`                          | ASAM ODS server        | Same result, server does the sequence-representation math |
+| `query()`              | One row per local column (metadata + `values` list)  | ODSBox (client)        | Cross-submatrix queries, custom JAQuel conditions, access to raw metadata |
+
+`data_read()` and `valuematrix_read()` return equivalent DataFrames for the
+same submatrix — the difference is only *where* raw/implicit sequence
+representations are resolved into concrete values. `data_read()` fetches the
+generation parameters and computes the values locally; `valuematrix_read()`
+asks the server to compute them (`ValueMatrixRequestStruct` with
+`MO_CALCULATED`). Use whichever fits your workflow; fall back to the other
+one if you hit a server- or client-side limitation.
+
+`query()` is the low-level building block both of the above are implemented
+on top of. Reach for it when you need to select local columns across
+multiple submatrices/measurements with a single JAQuel condition, or when you
+need access to local column metadata (`sequence_representation`,
+`submatrix`, `independent`, ...) alongside the values.
+
+## Basic examples
+
+```python
+# One DataFrame column per local column, matched by name pattern.
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Co*"])
+
+# Same result, calculated server-side.
+df = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Co*"])
+
+# Cross-submatrix query with a JAQuel condition.
+conditions = {"submatrix.measurement.name": {"$like": "Profile_5?"}}
+con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"])
+df = con_i.bulk.query(conditions)
+```
+
+`add_column_filters()` is a small helper that turns a list of column name
+patterns (`*`/`?` wildcards supported) into the equivalent JAQuel `$in`/`$like`
+condition — used internally by `data_read()`/`valuematrix_read()`, and
+available for `query()` callers that build their own conditions.
+
+## Quality filtering with `valid_flag` / `load_flags`
+
+ASAM ODS local columns can carry a `flags` attribute (one integer bitmask per
+value) describing the quality of each value. `data_read()`, `valuematrix_read()`
+and `query()` can use it to filter out invalid values instead of returning
+them as-is:
+
+```python
+# Replace values flagged as invalid (any of bits 0-3 set) with a missing value.
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], valid_flag=True)
+
+# Use a custom bitmask instead of the default (15).
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], valid_flag=0b0001)
+```
+
+* `valid_flag=None` (default): flags are not requested at all, values are
+  returned unmodified — this preserves the pre-existing behavior when the
+  parameter is not used.
+* `valid_flag=True` / `valid_flag=False`: both request flags and filter using
+  the default bitmask `15` (`0b1111`). They exist as convenient aliases and
+  behave identically — `False` does **not** mean "disable filtering".
+* `valid_flag=<int>`: filter using that specific bitmask instead of the
+  default.
+
+A value is considered invalid when `flags & valid_flag_bitmask != 0`.
+Filtered-out values become a missing value — `pandas.NA` for integer/boolean
+columns (the column is upcast to the matching pandas nullable dtype, e.g.
+`Int64`/`boolean`, so the dtype stays stable instead of silently becoming
+`object`) or plain `NaN` for floating point columns. Columns without any
+filtered value keep their original, non-nullable dtype.
+
+If the connected ASAM ODS model has no `flags` base attribute on
+`AoLocalColumn`, the parameter is silently ignored and no filtering happens.
+
+`query()` exposes the same mechanism through its `load_flags: bool` parameter,
+which only controls whether the `flags` attribute is requested — the
+resulting DataFrame carries a raw `flags` column per local column and no
+filtering is applied automatically, since `query()` returns one row per local
+column (metadata + values) rather than one column per local column.
+
+## Chunk loading and result metadata
+
+For very large submatrices, use `values_start`/`values_limit` to read data in
+chunks, and inspect `df.attrs["partial_result"]` to detect server-side
+truncation. Column units are available via `df.attrs["unit_names"]`. Both
+topics are covered in detail in [Partial Results and Unit Names](partial_results.md).
+
+## When BulkReader doesn't fit
+
+`BulkReader` covers the common cases, but it is intentionally a thin,
+readable wrapper — if your use case needs something it doesn't provide
+(e.g. a very custom bulk retrieval workflow), read its source
+(`src/odsbox/bulk_reader.py`) and build a tailored version for your client
+instead of fighting the abstraction.

--- a/docs/more/index.rst
+++ b/docs/more/index.rst
@@ -6,3 +6,4 @@ More
 
    ../session_context
    ../partial_results
+   ../con_read_bulk

--- a/src/odsbox/bulk_reader.py
+++ b/src/odsbox/bulk_reader.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pandas as pd
 
-from odsbox.datamatrices_to_pandas import extract_column_unit_ids, to_pandas
+from odsbox.datamatrices_to_pandas import ensure_nullable_dtype, extract_column_unit_ids, to_pandas
 from odsbox.proto.ods_pb2 import (
     DataMatrices,
     ValueMatrixRequestStruct,
@@ -62,6 +62,12 @@ class BulkReader:
 
     Remark: If the provided methods do not work for a client the source code can be used
     to create customer specific code to retrieve bulk data.
+
+    Remark: ``query()``, ``data_read()`` and ``valuematrix_read()`` support quality filtering
+    via ``load_flags``/``valid_flag``. When enabled, values whose ASAM ODS local column
+    ``flags`` bit-wise match the (default or given) bitmask are replaced by a missing value
+    (``pd.NA``, or ``NaN`` for floating point columns) instead of being dropped, so the
+    returned DataFrame keeps its original shape and column dtypes stay stable.
     """
 
     _log: logging.Logger = logging.getLogger(__name__)
@@ -210,6 +216,7 @@ class BulkReader:
         calculate_raw: bool = True,
         *,
         raise_on_partial_result: bool = False,
+        load_flags: bool = False,
     ) -> pd.DataFrame:
         """
         Query bulk data for local columns based on the provided Jaquel query condition.
@@ -242,6 +249,8 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            load_flags: If True, load the flags attribute for each local column. This requires that the AoLocalColumn
+                entity has an attribute derived from base name "flags".
 
         Returns:
             The Pandas DataFrame contains the local_column metadata and values as DataFrame columns.
@@ -270,14 +279,16 @@ class BulkReader:
                 "$options": {"$rowlimit": row_limit},
             }
         )
-        lc_meta_df.columns = [
-            "id",
-            "name",
-            "independent",
-            "sequence_representation",
-            "submatrix",
-            "number_of_rows",
-        ]
+        lc_meta_df.columns = pd.Index(
+            [
+                "id",
+                "name",
+                "independent",
+                "sequence_representation",
+                "submatrix",
+                "number_of_rows",
+            ]
+        )
         lc_meta_df.set_index("id", inplace=True)
 
         raw_seq_rep_values = {
@@ -296,6 +307,9 @@ class BulkReader:
         }
         if contains_raw_seq_rep:
             attributes["generation_parameters"] = 1
+
+        if load_flags and self.__con_i.mc.attribute_no_throw("AoLocalColumn", "flags") is not None:
+            attributes["flags"] = 1
 
         localcolumn_bulk_dms = self.__con_i.data_read_jaquel(
             {
@@ -318,7 +332,7 @@ class BulkReader:
         del localcolumn_bulk_dms  # free memory
         # capture partial_result flag before merge (pandas does not propagate .attrs through merge)
         partial_result = bool(localcolumn_bulk_df.attrs.get("partial_result", False))
-        localcolumn_bulk_df.columns = [attr for attr in attributes]
+        localcolumn_bulk_df.columns = pd.Index([attr for attr in attributes])
 
         # merge metadata into bulk, preserving bulk order (left join)
         merged: pd.DataFrame = localcolumn_bulk_df.merge(lc_meta_df, left_on="id", right_index=True, how="left")
@@ -356,6 +370,7 @@ class BulkReader:
         values_limit: int = 0,
         *,
         raise_on_partial_result: bool = False,
+        valid_flag: int | bool | None = None,
     ) -> pd.DataFrame:
         """
         Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame. The method uses the HTTP API method
@@ -385,6 +400,11 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            valid_flag: Integer bitmask used for quality filtering. Values whose flags
+                bitwise-AND with the effective bitmask are replaced with a missing value
+                (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+                column's original dtype stable. ``True``, ``False`` also map
+                to the default bitmask 15 and are there for simplicity.
 
         Returns:
             The Pandas DataFrame contains one column per local column, named after the local
@@ -408,10 +428,11 @@ class BulkReader:
             values_start=values_start,
             values_limit=values_limit,
             raise_on_partial_result=raise_on_partial_result,
+            load_flags=valid_flag is not None,
         )
 
         # Create DataFrame from column data
-        rv = pd.DataFrame({r["name"]: r["values"] for _, r in localcolumn_df.iterrows()})
+        rv: pd.DataFrame = self._create_dataframe_from_localcolumns(valid_flag, localcolumn_df)
         rv.attrs["unit_names"] = localcolumn_df.attrs.get("unit_names", {})
         rv.attrs["partial_result"] = bool(localcolumn_df.attrs.get("partial_result", False))
 
@@ -424,6 +445,40 @@ class BulkReader:
 
         return rv
 
+    @staticmethod
+    def _create_dataframe_from_localcolumns(
+        valid_flag: int | bool | None, localcolumn_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        if "flags" in localcolumn_df.columns:
+            valid_flag_value: int = 15 if isinstance(valid_flag, bool) or valid_flag is None else valid_flag
+            columns_data: dict[str, Any] = {}
+            for _, r in localcolumn_df.iterrows():
+                name = r["name"]
+                values = r["values"]
+                flags = r.get("flags")
+                if flags is not None and len(flags) > 0:
+                    flags_array = np.asarray(flags, dtype=int)
+                    if len(flags_array) != len(values):
+                        # servers may return flags in the same compact form used for implicit/raw
+                        # sequence representations (e.g. 2 samples for implicit_linear); a single
+                        # repeated flag value applies to every row, anything else can't be aligned
+                        unique_flags = np.unique(flags_array)
+                        if len(unique_flags) != 1:
+                            raise ValueError(
+                                f"'flags' length {len(flags_array)} does not match 'values' length "
+                                f"{len(values)} for column '{name}' and cannot be aligned."
+                            )
+                        flags_array = np.full(len(values), unique_flags[0])
+                    invalid_mask = (flags_array & valid_flag_value) != 0
+                    if invalid_mask.any():
+                        values = ensure_nullable_dtype(pd.Series(values))
+                        values.loc[invalid_mask] = pd.NA
+                columns_data[name] = values
+            rv = pd.DataFrame(columns_data)
+        else:
+            rv = pd.DataFrame({r["name"]: r["values"] for _, r in localcolumn_df.iterrows()})
+        return rv
+
     def valuematrix_read(
         self,
         submatrix_iid: int,
@@ -433,6 +488,7 @@ class BulkReader:
         values_limit: int = 0,
         *,
         raise_on_partial_result: bool = False,
+        valid_flag: int | bool | None = None,
     ) -> pd.DataFrame:
         """
         Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame.
@@ -459,6 +515,11 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            valid_flag: Integer bitmask used for quality filtering. Values whose flags
+                bitwise-AND with the effective bitmask are replaced with a missing value
+                (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+                column's original dtype stable. ``True``, ``False`` also map
+                to the default bitmask 15 and are there for simplicity.
 
         Returns:
             The Pandas DataFrame contains one column per local column, named after the local
@@ -475,16 +536,20 @@ class BulkReader:
         sm_e = self.__con_i.mc.entity_by_base_name("AoSubmatrix")
         lc_e = self.__con_i.mc.entity_by_base_name("AoLocalColumn")
         name_patterns = column_patterns or ["*"]
+        attribute_base_names = ["name", "values"]
+        if valid_flag is not None and self.__con_i.mc.attribute_no_throw("AoLocalColumn", "flags") is not None:
+            attribute_base_names.append("flags")
+
+        attributes = [
+            self.__con_i.mc.attribute_by_base_name(lc_e, base_name).name for base_name in attribute_base_names
+        ]
 
         raw_dms = self.__con_i.valuematrix_read(
             ValueMatrixRequestStruct(
                 aid=sm_e.aid,
                 iid=submatrix_iid,
                 columns=[ValueMatrixRequestStruct.ColumnItem(name=name_pattern) for name_pattern in name_patterns],
-                attributes=[
-                    self.__con_i.mc.attribute_by_base_name(lc_e, "name").name,
-                    self.__con_i.mc.attribute_by_base_name(lc_e, "values").name,
-                ],
+                attributes=attributes,
                 mode=ValueMatrixRequestStruct.ModeEnum.MO_CALCULATED,
                 values_start=values_start,
                 values_limit=values_limit,
@@ -499,8 +564,8 @@ class BulkReader:
         )
         del raw_dms  # free memory
         partial_result = bool(df.attrs.get("partial_result", False))
-        df.columns = ["name", "values"]
-        rv = pd.DataFrame({name: values for name, values in zip(df["name"].values, df["values"].values)})
+        df.columns = pd.Index(attribute_base_names)
+        rv = self._create_dataframe_from_localcolumns(valid_flag, df)
         self._attach_unit_attr(rv, df["name"], unit_names)
         rv.attrs["partial_result"] = partial_result
         return rv

--- a/src/odsbox/datamatrices_to_pandas.py
+++ b/src/odsbox/datamatrices_to_pandas.py
@@ -376,21 +376,7 @@ def to_pandas(
     if is_null_to_nan and null_masks:
         for column_name, null_mask in null_masks.items():
             mask_array = np.array(null_mask)
-
-            if rv[column_name].dtype == np.bool_:
-                rv[column_name] = rv[column_name].astype(pd.BooleanDtype())
-            elif pd.api.types.is_integer_dtype(rv[column_name].dtype):
-                if rv[column_name].dtype == np.uint8:
-                    rv[column_name] = rv[column_name].astype(pd.UInt8Dtype())
-                elif rv[column_name].dtype == np.int16:
-                    rv[column_name] = rv[column_name].astype(pd.Int16Dtype())
-                elif rv[column_name].dtype == np.int32:
-                    rv[column_name] = rv[column_name].astype(pd.Int32Dtype())
-                elif rv[column_name].dtype == np.int64:
-                    rv[column_name] = rv[column_name].astype(pd.Int64Dtype())
-                else:
-                    rv[column_name] = rv[column_name].astype(pd.Int64Dtype())  # fallback
-
+            rv[column_name] = ensure_nullable_dtype(rv[column_name])
             rv.loc[mask_array, column_name] = pd.NA
 
     return _set_partial_result_attr(rv, data_matrices)
@@ -399,3 +385,32 @@ def to_pandas(
 def _set_partial_result_attr(df: pd.DataFrame, data_matrices: ods.DataMatrices) -> pd.DataFrame:
     df.attrs["partial_result"] = data_matrices.partial_result
     return df
+
+
+def ensure_nullable_dtype(series: pd.Series) -> pd.Series:
+    """
+    Convert a numpy-backed boolean/integer Series to the matching pandas nullable dtype.
+
+    Plain numpy bool/int arrays cannot hold missing values, so assigning ``pd.NA`` into them
+    silently upcasts to ``float64`` or ``object`` and loses the original dtype. Converting to
+    the pandas nullable equivalent first keeps the dtype stable once ``pd.NA`` is assigned.
+    Series of any other dtype (e.g. float, object) already support missing values natively and
+    are returned unchanged.
+
+    Args:
+        series: The Series to convert.
+
+    Returns:
+        A Series using a pandas nullable dtype when applicable, otherwise the original Series.
+    """
+    if series.dtype == np.bool_:
+        return series.astype(pd.BooleanDtype())
+    if pd.api.types.is_integer_dtype(series.dtype):
+        nullable_dtype = {
+            np.dtype(np.uint8): pd.UInt8Dtype(),
+            np.dtype(np.int16): pd.Int16Dtype(),
+            np.dtype(np.int32): pd.Int32Dtype(),
+            np.dtype(np.int64): pd.Int64Dtype(),
+        }.get(series.dtype, pd.Int64Dtype())
+        return series.astype(nullable_dtype)
+    return series

--- a/src/odsbox/submatrix_to_pandas.py
+++ b/src/odsbox/submatrix_to_pandas.py
@@ -17,6 +17,8 @@ def submatrix_to_pandas(
     submatrix_iid: int,
     date_as_timestamp: bool = False,
     set_independent_as_index: bool = False,
+    *,
+    valid_flag: int | bool | None = None,
 ) -> pd.DataFrame:
     """
     Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame.
@@ -28,6 +30,11 @@ def submatrix_to_pandas(
         submatrix_iid: ID of a submatrix to be retrieved.
         date_as_timestamp: If True, DT_DATE/DS_DATE strings are converted to pandas Timestamp.
         set_independent_as_index: Whether to set the independent column as the index.
+        valid_flag: Integer bitmask used for quality filtering. Values whose flags
+            bitwise-AND with the effective bitmask are replaced with a missing value
+            (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+            column's original dtype stable. ``True``, ``False`` also map
+            to the default bitmask 15 and are there for simplicity.
 
     Returns:
         A pandas DataFrame containing the values of the localcolumn as pandas columns.
@@ -38,4 +45,5 @@ def submatrix_to_pandas(
         submatrix_iid=submatrix_iid,
         date_as_timestamp=date_as_timestamp,
         set_independent_as_index=set_independent_as_index,
+        valid_flag=valid_flag,
     )

--- a/tests/test_bulk_reader.py
+++ b/tests/test_bulk_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -787,3 +788,647 @@ def test_valuematrix_read_raise_on_partial_result_propagates(monkeypatch):
 
     with pytest.raises(PartialResultError):
         br.valuematrix_read(1, raise_on_partial_result=True)
+
+
+# --- Tests for valid_flag parameter of valuematrix_read() ---
+
+
+class _FakeMCForValuematrixValidFlag:
+    """Stand-in for mc used by valuematrix_read(), records attribute_no_throw() calls."""
+
+    def __init__(self, flags_attribute_exists: bool = True) -> None:
+        self.__flags_attribute_exists = flags_attribute_exists
+        self.attribute_no_throw_calls: list[tuple] = []
+
+    def entity_by_base_name(self, base_name):
+        return type("E", (), {"aid": 1})()
+
+    def attribute_by_base_name(self, entity, name):
+        return type("A", (), {"name": name})()
+
+    def attribute_no_throw(self, entity_or_name, application_or_base_name):
+        self.attribute_no_throw_calls.append((entity_or_name, application_or_base_name))
+        return object() if self.__flags_attribute_exists else None
+
+
+def _make_valuematrix_read_valid_flag_fake(flags_attribute_exists: bool = True):
+    """Build a minimal FakeConI whose mc records attribute_no_throw() calls."""
+
+    class FakeConI:
+        def __init__(self):
+            self.mc = _FakeMCForValuematrixValidFlag(flags_attribute_exists)
+
+        def valuematrix_read(self, vmreq):
+            return object()  # ignored by monkeypatched to_pandas
+
+    return FakeConI()
+
+
+def test_valuematrix_read_valid_flag_none_default_does_not_request_flags(monkeypatch) -> None:
+    """valid_flag defaults to None: 'flags' is neither requested nor even checked for existence."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Time", "Signal"], "values": [[0, 1, 2], [10, 20, 30]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake()
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1)
+
+    # attribute_no_throw is short-circuited away when valid_flag is None
+    assert fake.mc.attribute_no_throw_calls == []
+    assert list(df.columns) == ["Time", "Signal"]
+
+
+def test_valuematrix_read_valid_flag_true_requests_flags_and_masks_default_bitmask(monkeypatch) -> None:
+    """valid_flag=True requests 'flags' and masks values using the default bitmask (15)."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame(
+            {
+                "name": ["Time", "Signal"],
+                "values": [[0, 1, 2, 3], [10, 20, 30, 40]],
+                "flags": [[0, 0, 0, 0], [0, 1, 0, 8]],
+            }
+        )
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=True)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert "flags" not in df.columns
+    assert str(df["Signal"].dtype) == "Int64"
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+    # column without any invalid flags keeps its original (non-nullable) dtype
+    assert str(df["Time"].dtype) == "int64"
+    assert df["Time"].tolist() == [0, 1, 2, 3]
+
+
+def test_valuematrix_read_valid_flag_custom_bitmask_masks_only_matching_bits(monkeypatch) -> None:
+    """A custom integer valid_flag only masks values whose flags match that specific bitmask."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30, 40]], "flags": [[0, 1, 2, 3]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=1)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_valuematrix_read_valid_flag_true_but_attribute_missing_is_ignored(monkeypatch) -> None:
+    """valid_flag=True is silently ignored when AoLocalColumn has no 'flags' base attribute."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=False)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=True)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert "flags" not in df.columns
+    assert str(df["Signal"].dtype) == "int64"
+    assert df["Signal"].tolist() == [10, 20, 30]
+
+
+def test_valuematrix_read_valid_flag_false_also_masks_with_default_bitmask(monkeypatch) -> None:
+    """valid_flag=False is documented to behave like True/None: it still requests and masks with bitmask 15."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30, 40]], "flags": [[0, 1, 0, 8]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=False)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+# --- Tests for load_flags parameter of query() ---
+
+
+class _FakeMCAttribute:
+    """Stand-in for mc.attribute_no_throw(), controls whether the 'flags' attribute exists."""
+
+    def __init__(self, exists: bool) -> None:
+        self.__exists = exists
+
+    def attribute_no_throw(self, entity_or_name, application_or_base_name):
+        return object() if self.__exists else None
+
+
+def _make_load_flags_query_fake(exists: bool, captured_query: dict):
+    """Build a minimal FakeConI recording the jaquel query passed to data_read_jaquel()."""
+
+    class FakeConI:
+        def __init__(self):
+            self.mc = _FakeMCAttribute(exists)
+
+        def query_data(self, query):
+            return pd.DataFrame(
+                [
+                    {
+                        "id": 1,
+                        "name": "colA",
+                        "independent": False,
+                        "sequence_representation": SeqRepEnum.explicit.value,
+                        "submatrix": 20,
+                        "number_of_rows": 2,
+                    },
+                    {
+                        "id": 2,
+                        "name": "colB",
+                        "independent": False,
+                        "sequence_representation": SeqRepEnum.explicit.value,
+                        "submatrix": 20,
+                        "number_of_rows": 2,
+                    },
+                ]
+            )
+
+        def data_read_jaquel(self, jaquel_query):
+            captured_query.update(jaquel_query)
+            return object()  # ignored by monkeypatched to_pandas
+
+    return FakeConI()
+
+
+def test_query_load_flags_true_requests_and_returns_flags_when_attribute_exists(monkeypatch) -> None:
+    """load_flags=True adds 'flags' to the requested attributes and to the result when the attribute exists."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        # columns order matches attributes dict: id, values, flags
+        return pd.DataFrame([[1, [1, 2], [0, 1]], [2, [3, 4], [1, 0]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert "flags" in captured_query["$attributes"]
+    assert "flags" in merged.columns
+    assert list(merged["flags"]) == [[0, 1], [1, 0]]
+
+
+def test_query_load_flags_false_by_default_does_not_request_flags(monkeypatch) -> None:
+    """load_flags defaults to False: 'flags' must not be requested nor present in the result."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame([[1, [1, 2]], [2, [3, 4]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20})
+
+    assert "flags" not in captured_query["$attributes"]
+    assert "flags" not in merged.columns
+
+
+def test_query_load_flags_true_but_attribute_missing_is_ignored(monkeypatch) -> None:
+    """load_flags=True is silently ignored when AoLocalColumn has no 'flags' base attribute."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame([[1, [1, 2]], [2, [3, 4]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=False, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert "flags" not in captured_query["$attributes"]
+    assert "flags" not in merged.columns
+
+
+def test_query_load_flags_merges_with_metadata_preserving_order(monkeypatch) -> None:
+    """flags values are merged onto the correct row per local column id, preserving bulk order."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        # bulk order is [2, 1] here to make sure merge doesn't rely on sorted ids
+        return pd.DataFrame([[2, [3, 4], [1, 0]], [1, [1, 2], [0, 1]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert list(merged["name"]) == ["colB", "colA"]
+    assert list(merged["flags"]) == [[1, 0], [0, 1]]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_false_uses_default_mask() -> None:
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 0, 8],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(False, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_none_uses_default_mask() -> None:
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [1, 2, 3],
+                "flags": [0, 15, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(None, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [1, pd.NA, 3]
+
+
+# --- Tests for valid_flag parameter of data_read() ---
+
+
+def test_data_read_valid_flag_none_default_does_not_request_flags():
+    """valid_flag defaults to None: query() is called with load_flags=False and no masking occurs."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2], "independent": True},
+            {"name": "val", "values": [10, 11, 12], "independent": False},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False)
+
+    assert captured_kwargs["load_flags"] is False
+    assert df["val"].tolist() == [10, 11, 12]
+    assert str(df["val"].dtype) == "int64"
+
+
+def test_data_read_valid_flag_true_requests_flags_and_masks_default_bitmask():
+    """valid_flag=True requests flags from query() and masks values using the default bitmask (15)."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2, 3], "independent": True, "flags": [0, 0, 0, 0]},
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=True)
+
+    assert captured_kwargs["load_flags"] is True
+    assert str(df["val"].dtype) == "Int64"
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+    # column without any invalid flags keeps its original (non-nullable) dtype
+    assert str(df["time"].dtype) == "int64"
+    assert df["time"].tolist() == [0, 1, 2, 3]
+
+
+def test_data_read_valid_flag_custom_bitmask_masks_only_matching_bits():
+    """A custom integer valid_flag only masks values whose flags match that specific bitmask."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 2, 3]},
+        ]
+    )
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=1)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_data_read_valid_flag_false_also_requests_and_masks_with_default_bitmask():
+    """valid_flag=False is documented to behave like True/None: it still requests and masks with bitmask 15."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=False)
+
+    # False is not None, so flags are still requested from query()
+    assert captured_kwargs["load_flags"] is True
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_data_read_valid_flag_preserves_unit_names_and_partial_result_attrs():
+    """valid_flag masking must not interfere with existing unit_names/partial_result propagation."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30], "independent": False, "flags": [0, 1, 0]},
+        ]
+    )
+    qdf.attrs["unit_names"] = {"val": "N"}
+    qdf.attrs["partial_result"] = True
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=True)
+
+    assert df.attrs["unit_names"] == {"val": "N"}
+    assert df.attrs["partial_result"] is True
+    assert df["val"].tolist() == [10, pd.NA, 30]
+
+
+def test_data_read_valid_flag_with_independent_index_set():
+    """valid_flag composes correctly with set_independent_as_index=True."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2], "independent": True, "flags": [0, 0, 0]},
+            {"name": "val", "values": [10, 20, 30], "independent": False, "flags": [0, 1, 0]},
+        ]
+    )
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=True, valid_flag=True)
+
+    assert df.index.tolist() == [0, 1, 2]
+    assert list(df.columns) == ["val"]
+    assert df["val"].tolist() == [10, pd.NA, 30]
+
+
+# --- Additional tests for _create_dataframe_from_localcolumns (static method) ---
+
+
+def test_create_dataframe_from_localcolumns_without_flags_column_returns_values_unchanged():
+    """When 'flags' is not part of the metadata, values are used verbatim regardless of valid_flag."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2]},
+            {"name": "Signal", "values": [10, 20, 30]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert list(rv.columns) == ["Time", "Signal"]
+    assert rv["Time"].tolist() == [0, 1, 2]
+    assert rv["Signal"].tolist() == [10, 20, 30]
+    assert str(rv["Signal"].dtype) == "int64"
+
+
+def test_create_dataframe_from_localcolumns_custom_int_bitmask():
+    """A custom integer bitmask only masks values whose flags match that specific mask."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 2, 3],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(1, localcolumn_df)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_true_matches_default_mask():
+    """valid_flag=True behaves identically to False/None: all map to the default bitmask 15."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 0, 8],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_no_invalid_flags_keeps_original_dtype():
+    """When no flag matches the bitmask, values keep their original (non-nullable) dtype."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30],
+                "flags": [0, 0, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "int64"
+    assert rv["Signal"].tolist() == [10, 20, 30]
+
+
+def test_create_dataframe_from_localcolumns_empty_flags_list_skips_masking():
+    """An empty flags list (e.g. a zero-row column) leaves the values untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [],
+                "flags": [],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert rv["Signal"].tolist() == []
+
+
+def test_create_dataframe_from_localcolumns_float_values_use_nan_for_masked():
+    """Float columns keep their float dtype and use NaN (not pd.NA) for masked entries."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": np.array([1.5, 2.5, 3.5], dtype=float),
+                "flags": [0, 1, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "float64"
+    assert rv["Signal"].iloc[0] == 1.5
+    assert np.isnan(rv["Signal"].iloc[1])
+    assert rv["Signal"].iloc[2] == 3.5
+
+
+def test_create_dataframe_from_localcolumns_boolean_values_use_nullable_boolean():
+    """Boolean columns convert to the nullable BooleanDtype so pd.NA can be stored."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": np.array([True, False, True]),
+                "flags": [0, 1, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "boolean"
+    assert rv["Signal"].tolist() == [True, pd.NA, True]
+
+
+def test_create_dataframe_from_localcolumns_multiple_columns_independent_masking():
+    """Each local column's mask is computed independently; unaffected columns are untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 0, 0, 0]},
+            {"name": "Signal", "values": [10, 20, 30, 40], "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "int64"
+    assert rv["Time"].tolist() == [0, 1, 2, 3]
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_constant_flags_shorter_than_values_are_broadcast():
+    """Servers may return 'flags' in the same compact form used for implicit/raw sequence
+    representations (e.g. 2 samples for an implicit_linear column with 4 rows). When every
+    returned flag sample is identical, that single value must apply to every row."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [15, 15]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "Int64"
+    assert rv["Time"].tolist() == [pd.NA, pd.NA, pd.NA, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_constant_valid_flags_shorter_than_values_no_masking():
+    """A short constant 'flags' sample that does not match the bitmask leaves values untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 0]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "int64"
+    assert rv["Time"].tolist() == [0, 1, 2, 3]
+
+
+def test_create_dataframe_from_localcolumns_non_constant_length_mismatch_raises():
+    """A 'flags' array that neither matches the values length nor is constant cannot be aligned."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 15]},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cannot be aligned"):
+        BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)

--- a/tests/test_bulk_reader_integration.py
+++ b/tests/test_bulk_reader_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -98,6 +99,101 @@ def test_bulk_reader_query():
             assert len(time_vals) > 0
             assert len(coolant_vals) > 0
             assert len(time_vals) == len(coolant_vals)
+
+
+@pytest.mark.integration
+def test_bulk_reader_query_load_flags() -> None:
+    with __create_con_i() as con_i:
+        conditions = {"submatrix.measurement.name": {"$like": "Profile_5?"}}
+        con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"], column_patterns_case_insensitive=False)
+
+        # AoLocalColumn.flags is not requested unless load_flags=True
+        df_without_flags = con_i.bulk.query(conditions, load_flags=False)
+        assert df_without_flags.empty is False
+        assert "flags" not in df_without_flags.columns
+
+        df_with_flags = con_i.bulk.query(conditions, load_flags=True)
+        assert df_with_flags.empty is False
+        assert "flags" in df_with_flags.columns
+        for flags in df_with_flags["flags"]:
+            assert len(flags) > 0
+
+        # requesting flags must not change the other columns/values
+        pd.testing.assert_frame_equal(df_without_flags, df_with_flags.drop(columns=["flags"]))
+
+
+@pytest.mark.integration
+def test_bulk_reader_data_read_valid_flag() -> None:
+    with __create_con_i() as con_i:
+        sm_s = con_i.query_data(
+            {
+                "AoSubmatrix": {"measurement.name": "Profile_52"},
+                "$options": {"$rowlimit": 1},
+                "$attributes": {"id": 1, "measurement.name": 1},
+            }
+        )
+
+        assert sm_s.shape[0] <= 1
+        if 1 == sm_s.shape[0]:
+            submatrix_id = int(sm_s.iloc[0, 0])
+
+            df_plain = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], set_independent_as_index=False)
+
+            # independently fetch the raw flags to derive the expected mask
+            conditions = {"submatrix": submatrix_id}
+            con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"], column_patterns_case_insensitive=False)
+            flagged = con_i.bulk.query(conditions, load_flags=True)
+            assert "flags" in flagged.columns
+
+            df_filtered = con_i.bulk.data_read(
+                submatrix_id, ["Time", "Coolant"], set_independent_as_index=False, valid_flag=True
+            )
+
+            assert list(df_filtered.columns) == list(df_plain.columns)
+            for _, row in flagged.iterrows():
+                name = row["name"]
+                flags = np.asarray(row["flags"], dtype=int)
+                if len(flags) != len(df_plain[name]):
+                    # servers may return flags in the same compact form used for implicit/raw
+                    # sequence representations; a constant sample set applies to every row
+                    assert len(np.unique(flags)) == 1
+                    flags = np.full(len(df_plain[name]), flags[0])
+                invalid_mask = (flags & 15) != 0
+                if invalid_mask.any():
+                    assert df_filtered[name].isna().tolist() == invalid_mask.tolist()
+                    assert df_filtered[name][~invalid_mask].tolist() == df_plain[name][~invalid_mask].tolist()
+                else:
+                    pd.testing.assert_series_equal(df_filtered[name], df_plain[name], check_names=False)
+
+
+@pytest.mark.integration
+def test_bulk_reader_valuematrix_read_valid_flag() -> None:
+    with __create_con_i() as con_i:
+        sm_s = con_i.query_data(
+            {
+                "AoSubmatrix": {"measurement.name": "Profile_52"},
+                "$options": {"$rowlimit": 1},
+                "$attributes": {"id": 1, "measurement.name": 1},
+            }
+        )
+
+        assert sm_s.shape[0] <= 1
+        if 1 == sm_s.shape[0]:
+            submatrix_id = int(sm_s.iloc[0, 0])
+
+            # data_read()'s masking is already verified independently above; use it as the
+            # reference to confirm valuematrix_read() applies the same masking for valid_flag.
+            df_data_read = con_i.bulk.data_read(
+                submatrix_id, ["Time", "Coolant"], set_independent_as_index=False, valid_flag=True
+            )
+            df_valuematrix = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Coolant"], valid_flag=True)
+
+            pd.testing.assert_frame_equal(df_data_read, df_valuematrix)
+            assert df_valuematrix.attrs["unit_names"] == df_data_read.attrs["unit_names"]
+
+            # plain read (no valid_flag) must still work and keep the same columns
+            df_plain = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Coolant"])
+            assert list(df_plain.columns) == list(df_valuematrix.columns)
 
 
 @pytest.mark.integration

--- a/tests/test_submatrix_to_pandas.py
+++ b/tests/test_submatrix_to_pandas.py
@@ -16,6 +16,8 @@ Test map
     - test_passes_set_independent_as_index_false_to_bulk_reader
         Verifies the wrapper correctly forwards `set_independent_as_index=False`
         to `BulkReader.data_read`.
+    - test_passes_valid_flag_to_bulk_reader
+        Verifies the wrapper correctly forwards `valid_flag` to `BulkReader.data_read`.
     - test_can_opt_in_to_set_independent_as_index
         Verifies that passing `set_independent_as_index=True` promotes the
         independent column to the index (opt-in path).
@@ -122,6 +124,24 @@ class TestSubmatrixToPandasDefaultBehavior:
             submatrix_iid=42,
             date_as_timestamp=False,
             set_independent_as_index=False,
+            valid_flag=None,
+        )
+
+    def test_passes_valid_flag_to_bulk_reader(self):
+        """`submatrix_to_pandas` must forward `valid_flag` to `BulkReader.data_read`."""
+        con_i = MagicMock()
+
+        with patch("odsbox.submatrix_to_pandas.BulkReader") as MockBulkReader:
+            mock_br = MockBulkReader.return_value
+            mock_br.data_read.return_value = pd.DataFrame({"time": [0], "speed": [10]})
+
+            submatrix_to_pandas(con_i, submatrix_iid=42, valid_flag=1)
+
+        mock_br.data_read.assert_called_once_with(
+            submatrix_iid=42,
+            date_as_timestamp=False,
+            set_independent_as_index=False,
+            valid_flag=1,
         )
 
     def test_can_opt_in_to_set_independent_as_index(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1676,7 +1676,7 @@ wheels = [
 
 [[package]]
 name = "odsbox"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
This pull request introduces comprehensive support for quality flag-based filtering of bulk data in the `BulkReader` class, making it easier for users to filter out invalid values when reading timeseries or bulk data from ASAM ODS sources. The filtering mechanism ensures that filtered values are replaced with missing values (`pd.NA` or `NaN`) while preserving the DataFrame's original shape and stable dtypes. The changes also include documentation updates and minor improvements to code clarity and editor settings.

**Bulk data quality filtering and API improvements:**

* Added `valid_flag` parameter to `data_read()` and `valuematrix_read()` methods, allowing users to specify a bitmask for filtering out invalid values based on quality flags. Filtered values are replaced with missing values, and column dtypes are preserved. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R373) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R403-R407) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R491) [[4]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R518-R522)
* Enhanced the `query()` method with a `load_flags` parameter, enabling retrieval of the `flags` attribute for each local column when available. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R219) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R252-R253) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R311-R313)
* Introduced a shared `_create_dataframe_from_localcolumns()` helper to handle application of quality filtering and correct dtype handling for columns with flags. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R448-R481) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R431-R435) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R539-R552) [[4]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783L502-R568)
* Updated the `to_pandas` conversion logic to use a new `ensure_nullable_dtype` function for consistent dtype handling when null values are introduced. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783L12-R12) [[2]](diffhunk://#diff-a2fc602c2d3615d322c35f87565cccab61056b5ef477928866aa196bfecea13bL379-R379)

**Documentation and usability:**

* Added a new `docs/con_read_bulk.md` guide explaining how to use `BulkReader` methods, the new quality filtering features, and practical usage examples.
* Linked the new guide from the documentation index for discoverability.
* Improved docstrings and comments throughout `bulk_reader.py` to clarify the behavior and usage of new parameters. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R65-R70) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R252-R253) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R403-R407) [[4]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R518-R522)

**Editor and configuration:**

* Added `"nullable"` to the VSCode spell checker ignore list and set `chat.disableAIFeatures` to `false` in `.vscode/settings.json`. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R57) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L74-R76)Introduce the ability to use localcolumn flags in the BulkReader, enhancing data quality filtering capabilities. This update includes modifications to the `submatrix_to_pandas` function to forward a valid flag and updates tests to verify the correct behavior of this new feature.