### PR TITLE
feat: allow BulkReader to load localcolumn flags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -102,7 +102,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: main
-      - uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v10.0.1
       - name: Install Pandoc
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Install docs dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,7 @@
         "NOTINSET",
         "NOTLIKE",
         "notnull",
+        "nullable",
         "odsbox",
         "Oneof",
         "preconfigured",
@@ -71,5 +72,6 @@
         "TESTSTEP",
         "valuematrix",
         "webfinger"
-    ]
+    ],
+    "chat.disableAIFeatures": false
 }

--- a/docs/con_read_bulk.md
+++ b/docs/con_read_bulk.md
@@ -1,0 +1,127 @@
+# Reading Bulk Data with `BulkReader`
+
+ASAM ODS stores measured/calculated values ("timeseries", "bulk data") in `AoLocalColumn`
+instances that belong to an `AoSubMatrix`. The raw ASAM ODS HTTP API models
+this in a way that is efficient over the wire but inconvenient to consume
+directly:
+
+* A local column's values are not always stored explicitly. They can be
+  described indirectly through a *sequence representation* (constant,
+  linear, raw-linear with calibration factors, rational, ...) plus a small
+  set of *generation parameters*, and the actual values have to be derived
+  from those parameters.
+* Values, units, and quality flags live in separate attributes/entities that
+  need to be queried and joined together.
+* The wire format is protobuf (`DataMatrices` / value matrices), not
+  something you want to work with directly in an analysis script.
+* The submatrix bundles local columns that have the same number of values and
+  the same independent column (e.g. "Time"), but you may want to read only a
+  subset of them.
+
+`BulkReader` exists to hide all of that and hand you a plain
+`pandas.DataFrame` instead. You don't use it directly — every `ConI` session
+exposes a ready-to-use instance via the `bulk` property:
+
+```python
+from odsbox.con_i import ConI
+
+with ConI(url="https://MYSERVER/api", auth=("USER", "PASSWORD")) as con_i:
+    df = con_i.bulk.data_read(submatrix_id, ["Time", "Co*"])
+```
+
+## Which method should I use?
+
+| Method                | Returns                                            | Values calculated by | Typical use case |
+| --------------------- | --------------------------------------------------- | --------------------- | ----------------- |
+| `data_read()`          | One column per local column, named by column name   | ODSBox (client)        | Default choice for reading a single submatrix |
+| `valuematrix_read()`   | Same shape as `data_read()`                          | ASAM ODS server        | Same result, server does the sequence-representation math |
+| `query()`              | One row per local column (metadata + `values` list)  | ODSBox (client)        | Cross-submatrix queries, custom JAQuel conditions, access to raw metadata |
+
+`data_read()` and `valuematrix_read()` return equivalent DataFrames for the
+same submatrix — the difference is only *where* raw/implicit sequence
+representations are resolved into concrete values. `data_read()` fetches the
+generation parameters and computes the values locally; `valuematrix_read()`
+asks the server to compute them (`ValueMatrixRequestStruct` with
+`MO_CALCULATED`). Use whichever fits your workflow; fall back to the other
+one if you hit a server- or client-side limitation.
+
+`query()` is the low-level building block both of the above are implemented
+on top of. Reach for it when you need to select local columns across
+multiple submatrices/measurements with a single JAQuel condition, or when you
+need access to local column metadata (`sequence_representation`,
+`submatrix`, `independent`, ...) alongside the values.
+
+## Basic examples
+
+```python
+# One DataFrame column per local column, matched by name pattern.
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Co*"])
+
+# Same result, calculated server-side.
+df = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Co*"])
+
+# Cross-submatrix query with a JAQuel condition.
+conditions = {"submatrix.measurement.name": {"$like": "Profile_5?"}}
+con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"])
+df = con_i.bulk.query(conditions)
+```
+
+`add_column_filters()` is a small helper that turns a list of column name
+patterns (`*`/`?` wildcards supported) into the equivalent JAQuel `$in`/`$like`
+condition — used internally by `data_read()`/`valuematrix_read()`, and
+available for `query()` callers that build their own conditions.
+
+## Quality filtering with `valid_flag` / `load_flags`
+
+ASAM ODS local columns can carry a `flags` attribute (one integer bitmask per
+value) describing the quality of each value. `data_read()`, `valuematrix_read()`
+and `query()` can use it to filter out invalid values instead of returning
+them as-is:
+
+```python
+# Replace values flagged as invalid (any of bits 0-3 set) with a missing value.
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], valid_flag=True)
+
+# Use a custom bitmask instead of the default (15).
+df = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], valid_flag=0b0001)
+```
+
+* `valid_flag=None` (default): flags are not requested at all, values are
+  returned unmodified — this preserves the pre-existing behavior when the
+  parameter is not used.
+* `valid_flag=True` / `valid_flag=False`: both request flags and filter using
+  the default bitmask `15` (`0b1111`). They exist as convenient aliases and
+  behave identically — `False` does **not** mean "disable filtering".
+* `valid_flag=<int>`: filter using that specific bitmask instead of the
+  default.
+
+A value is considered invalid when `flags & valid_flag_bitmask != 0`.
+Filtered-out values become a missing value — `pandas.NA` for integer/boolean
+columns (the column is upcast to the matching pandas nullable dtype, e.g.
+`Int64`/`boolean`, so the dtype stays stable instead of silently becoming
+`object`) or plain `NaN` for floating point columns. Columns without any
+filtered value keep their original, non-nullable dtype.
+
+If the connected ASAM ODS model has no `flags` base attribute on
+`AoLocalColumn`, the parameter is silently ignored and no filtering happens.
+
+`query()` exposes the same mechanism through its `load_flags: bool` parameter,
+which only controls whether the `flags` attribute is requested — the
+resulting DataFrame carries a raw `flags` column per local column and no
+filtering is applied automatically, since `query()` returns one row per local
+column (metadata + values) rather than one column per local column.
+
+## Chunk loading and result metadata
+
+For very large submatrices, use `values_start`/`values_limit` to read data in
+chunks, and inspect `df.attrs["partial_result"]` to detect server-side
+truncation. Column units are available via `df.attrs["unit_names"]`. Both
+topics are covered in detail in [Partial Results and Unit Names](partial_results.md).
+
+## When BulkReader doesn't fit
+
+`BulkReader` covers the common cases, but it is intentionally a thin,
+readable wrapper — if your use case needs something it doesn't provide
+(e.g. a very custom bulk retrieval workflow), read its source
+(`src/odsbox/bulk_reader.py`) and build a tailored version for your client
+instead of fighting the abstraction.

--- a/docs/more/index.rst
+++ b/docs/more/index.rst
@@ -6,3 +6,4 @@ More
 
    ../session_context
    ../partial_results
+   ../con_read_bulk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "types-requests>=2.30.0",
     "click>=8.3.3",
     "msgpack>=1.2.1",
+    "pip>=26.2",
 ]
 docs = [
     "sphinx>=8.0.0",

--- a/src/odsbox/bulk_reader.py
+++ b/src/odsbox/bulk_reader.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pandas as pd
 
-from odsbox.datamatrices_to_pandas import extract_column_unit_ids, to_pandas
+from odsbox.datamatrices_to_pandas import ensure_nullable_dtype, extract_column_unit_ids, to_pandas
 from odsbox.proto.ods_pb2 import (
     DataMatrices,
     ValueMatrixRequestStruct,
@@ -62,6 +62,12 @@ class BulkReader:
 
     Remark: If the provided methods do not work for a client the source code can be used
     to create customer specific code to retrieve bulk data.
+
+    Remark: ``query()``, ``data_read()`` and ``valuematrix_read()`` support quality filtering
+    via ``load_flags``/``valid_flag``. When enabled, values whose ASAM ODS local column
+    ``flags`` bit-wise match the (default or given) bitmask are replaced by a missing value
+    (``pd.NA``, or ``NaN`` for floating point columns) instead of being dropped, so the
+    returned DataFrame keeps its original shape and column dtypes stay stable.
     """
 
     _log: logging.Logger = logging.getLogger(__name__)
@@ -210,6 +216,7 @@ class BulkReader:
         calculate_raw: bool = True,
         *,
         raise_on_partial_result: bool = False,
+        load_flags: bool = False,
     ) -> pd.DataFrame:
         """
         Query bulk data for local columns based on the provided Jaquel query condition.
@@ -242,6 +249,8 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            load_flags: If True, load the flags attribute for each local column. This requires that the AoLocalColumn
+                entity has an attribute derived from base name "flags".
 
         Returns:
             The Pandas DataFrame contains the local_column metadata and values as DataFrame columns.
@@ -270,14 +279,16 @@ class BulkReader:
                 "$options": {"$rowlimit": row_limit},
             }
         )
-        lc_meta_df.columns = [
-            "id",
-            "name",
-            "independent",
-            "sequence_representation",
-            "submatrix",
-            "number_of_rows",
-        ]
+        lc_meta_df.columns = pd.Index(
+            [
+                "id",
+                "name",
+                "independent",
+                "sequence_representation",
+                "submatrix",
+                "number_of_rows",
+            ]
+        )
         lc_meta_df.set_index("id", inplace=True)
 
         raw_seq_rep_values = {
@@ -296,6 +307,9 @@ class BulkReader:
         }
         if contains_raw_seq_rep:
             attributes["generation_parameters"] = 1
+
+        if load_flags and self.__con_i.mc.attribute_no_throw("AoLocalColumn", "flags") is not None:
+            attributes["flags"] = 1
 
         localcolumn_bulk_dms = self.__con_i.data_read_jaquel(
             {
@@ -318,7 +332,7 @@ class BulkReader:
         del localcolumn_bulk_dms  # free memory
         # capture partial_result flag before merge (pandas does not propagate .attrs through merge)
         partial_result = bool(localcolumn_bulk_df.attrs.get("partial_result", False))
-        localcolumn_bulk_df.columns = [attr for attr in attributes]
+        localcolumn_bulk_df.columns = pd.Index([attr for attr in attributes])
 
         # merge metadata into bulk, preserving bulk order (left join)
         merged: pd.DataFrame = localcolumn_bulk_df.merge(lc_meta_df, left_on="id", right_index=True, how="left")
@@ -356,6 +370,7 @@ class BulkReader:
         values_limit: int = 0,
         *,
         raise_on_partial_result: bool = False,
+        valid_flag: int | bool | None = None,
     ) -> pd.DataFrame:
         """
         Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame. The method uses the HTTP API method
@@ -385,6 +400,11 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            valid_flag: Integer bitmask used for quality filtering. Values whose flags
+                bitwise-AND with the effective bitmask are replaced with a missing value
+                (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+                column's original dtype stable. ``True``, ``False`` also map
+                to the default bitmask 15 and are there for simplicity.
 
         Returns:
             The Pandas DataFrame contains one column per local column, named after the local
@@ -408,10 +428,11 @@ class BulkReader:
             values_start=values_start,
             values_limit=values_limit,
             raise_on_partial_result=raise_on_partial_result,
+            load_flags=valid_flag is not None,
         )
 
         # Create DataFrame from column data
-        rv = pd.DataFrame({r["name"]: r["values"] for _, r in localcolumn_df.iterrows()})
+        rv: pd.DataFrame = self._create_dataframe_from_localcolumns(valid_flag, localcolumn_df)
         rv.attrs["unit_names"] = localcolumn_df.attrs.get("unit_names", {})
         rv.attrs["partial_result"] = bool(localcolumn_df.attrs.get("partial_result", False))
 
@@ -424,6 +445,40 @@ class BulkReader:
 
         return rv
 
+    @staticmethod
+    def _create_dataframe_from_localcolumns(
+        valid_flag: int | bool | None, localcolumn_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        if "flags" in localcolumn_df.columns:
+            valid_flag_value: int = 15 if isinstance(valid_flag, bool) or valid_flag is None else valid_flag
+            columns_data: dict[str, Any] = {}
+            for _, r in localcolumn_df.iterrows():
+                name = r["name"]
+                values = r["values"]
+                flags = r.get("flags")
+                if flags is not None and len(flags) > 0:
+                    flags_array = np.asarray(flags, dtype=int)
+                    if len(flags_array) != len(values):
+                        # servers may return flags in the same compact form used for implicit/raw
+                        # sequence representations (e.g. 2 samples for implicit_linear); a single
+                        # repeated flag value applies to every row, anything else can't be aligned
+                        unique_flags = np.unique(flags_array)
+                        if len(unique_flags) != 1:
+                            raise ValueError(
+                                f"'flags' length {len(flags_array)} does not match 'values' length "
+                                f"{len(values)} for column '{name}' and cannot be aligned."
+                            )
+                        flags_array = np.full(len(values), unique_flags[0])
+                    invalid_mask = (flags_array & valid_flag_value) != 0
+                    if invalid_mask.any():
+                        values = ensure_nullable_dtype(pd.Series(values))
+                        values.loc[invalid_mask] = pd.NA
+                columns_data[name] = values
+            rv = pd.DataFrame(columns_data)
+        else:
+            rv = pd.DataFrame({r["name"]: r["values"] for _, r in localcolumn_df.iterrows()})
+        return rv
+
     def valuematrix_read(
         self,
         submatrix_iid: int,
@@ -433,6 +488,7 @@ class BulkReader:
         values_limit: int = 0,
         *,
         raise_on_partial_result: bool = False,
+        valid_flag: int | bool | None = None,
     ) -> pd.DataFrame:
         """
         Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame.
@@ -459,6 +515,11 @@ class BulkReader:
                 :class:`~odsbox.datamatrices_to_pandas.PartialResultError` when the server
                 returns a partial result instead of returning a truncated DataFrame.
                 Defaults to False to preserve existing behavior.
+            valid_flag: Integer bitmask used for quality filtering. Values whose flags
+                bitwise-AND with the effective bitmask are replaced with a missing value
+                (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+                column's original dtype stable. ``True``, ``False`` also map
+                to the default bitmask 15 and are there for simplicity.
 
         Returns:
             The Pandas DataFrame contains one column per local column, named after the local
@@ -475,16 +536,20 @@ class BulkReader:
         sm_e = self.__con_i.mc.entity_by_base_name("AoSubmatrix")
         lc_e = self.__con_i.mc.entity_by_base_name("AoLocalColumn")
         name_patterns = column_patterns or ["*"]
+        attribute_base_names = ["name", "values"]
+        if valid_flag is not None and self.__con_i.mc.attribute_no_throw("AoLocalColumn", "flags") is not None:
+            attribute_base_names.append("flags")
+
+        attributes = [
+            self.__con_i.mc.attribute_by_base_name(lc_e, base_name).name for base_name in attribute_base_names
+        ]
 
         raw_dms = self.__con_i.valuematrix_read(
             ValueMatrixRequestStruct(
                 aid=sm_e.aid,
                 iid=submatrix_iid,
                 columns=[ValueMatrixRequestStruct.ColumnItem(name=name_pattern) for name_pattern in name_patterns],
-                attributes=[
-                    self.__con_i.mc.attribute_by_base_name(lc_e, "name").name,
-                    self.__con_i.mc.attribute_by_base_name(lc_e, "values").name,
-                ],
+                attributes=attributes,
                 mode=ValueMatrixRequestStruct.ModeEnum.MO_CALCULATED,
                 values_start=values_start,
                 values_limit=values_limit,
@@ -499,8 +564,8 @@ class BulkReader:
         )
         del raw_dms  # free memory
         partial_result = bool(df.attrs.get("partial_result", False))
-        df.columns = ["name", "values"]
-        rv = pd.DataFrame({name: values for name, values in zip(df["name"].values, df["values"].values)})
+        df.columns = pd.Index(attribute_base_names)
+        rv = self._create_dataframe_from_localcolumns(valid_flag, df)
         self._attach_unit_attr(rv, df["name"], unit_names)
         rv.attrs["partial_result"] = partial_result
         return rv

--- a/src/odsbox/datamatrices_to_pandas.py
+++ b/src/odsbox/datamatrices_to_pandas.py
@@ -376,21 +376,7 @@ def to_pandas(
     if is_null_to_nan and null_masks:
         for column_name, null_mask in null_masks.items():
             mask_array = np.array(null_mask)
-
-            if rv[column_name].dtype == np.bool_:
-                rv[column_name] = rv[column_name].astype(pd.BooleanDtype())
-            elif pd.api.types.is_integer_dtype(rv[column_name].dtype):
-                if rv[column_name].dtype == np.uint8:
-                    rv[column_name] = rv[column_name].astype(pd.UInt8Dtype())
-                elif rv[column_name].dtype == np.int16:
-                    rv[column_name] = rv[column_name].astype(pd.Int16Dtype())
-                elif rv[column_name].dtype == np.int32:
-                    rv[column_name] = rv[column_name].astype(pd.Int32Dtype())
-                elif rv[column_name].dtype == np.int64:
-                    rv[column_name] = rv[column_name].astype(pd.Int64Dtype())
-                else:
-                    rv[column_name] = rv[column_name].astype(pd.Int64Dtype())  # fallback
-
+            rv[column_name] = ensure_nullable_dtype(rv[column_name])
             rv.loc[mask_array, column_name] = pd.NA
 
     return _set_partial_result_attr(rv, data_matrices)
@@ -399,3 +385,32 @@ def to_pandas(
 def _set_partial_result_attr(df: pd.DataFrame, data_matrices: ods.DataMatrices) -> pd.DataFrame:
     df.attrs["partial_result"] = data_matrices.partial_result
     return df
+
+
+def ensure_nullable_dtype(series: pd.Series) -> pd.Series:
+    """
+    Convert a numpy-backed boolean/integer Series to the matching pandas nullable dtype.
+
+    Plain numpy bool/int arrays cannot hold missing values, so assigning ``pd.NA`` into them
+    silently upcasts to ``float64`` or ``object`` and loses the original dtype. Converting to
+    the pandas nullable equivalent first keeps the dtype stable once ``pd.NA`` is assigned.
+    Series of any other dtype (e.g. float, object) already support missing values natively and
+    are returned unchanged.
+
+    Args:
+        series: The Series to convert.
+
+    Returns:
+        A Series using a pandas nullable dtype when applicable, otherwise the original Series.
+    """
+    if series.dtype == np.bool_:
+        return series.astype(pd.BooleanDtype())
+    if pd.api.types.is_integer_dtype(series.dtype):
+        nullable_dtype = {
+            np.dtype(np.uint8): pd.UInt8Dtype(),
+            np.dtype(np.int16): pd.Int16Dtype(),
+            np.dtype(np.int32): pd.Int32Dtype(),
+            np.dtype(np.int64): pd.Int64Dtype(),
+        }.get(series.dtype, pd.Int64Dtype())
+        return series.astype(nullable_dtype)
+    return series

--- a/src/odsbox/submatrix_to_pandas.py
+++ b/src/odsbox/submatrix_to_pandas.py
@@ -17,6 +17,8 @@ def submatrix_to_pandas(
     submatrix_iid: int,
     date_as_timestamp: bool = False,
     set_independent_as_index: bool = False,
+    *,
+    valid_flag: int | bool | None = None,
 ) -> pd.DataFrame:
     """
     Loads an ASAM ODS SubMatrix and returns it as a pandas DataFrame.
@@ -28,6 +30,11 @@ def submatrix_to_pandas(
         submatrix_iid: ID of a submatrix to be retrieved.
         date_as_timestamp: If True, DT_DATE/DS_DATE strings are converted to pandas Timestamp.
         set_independent_as_index: Whether to set the independent column as the index.
+        valid_flag: Integer bitmask used for quality filtering. Values whose flags
+            bitwise-AND with the effective bitmask are replaced with a missing value
+            (``pd.NA``, or ``NaN`` for floating point columns) while keeping the
+            column's original dtype stable. ``True``, ``False`` also map
+            to the default bitmask 15 and are there for simplicity.
 
     Returns:
         A pandas DataFrame containing the values of the localcolumn as pandas columns.
@@ -38,4 +45,5 @@ def submatrix_to_pandas(
         submatrix_iid=submatrix_iid,
         date_as_timestamp=date_as_timestamp,
         set_independent_as_index=set_independent_as_index,
+        valid_flag=valid_flag,
     )

--- a/tests/test_bulk_reader.py
+++ b/tests/test_bulk_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -787,3 +788,647 @@ def test_valuematrix_read_raise_on_partial_result_propagates(monkeypatch):
 
     with pytest.raises(PartialResultError):
         br.valuematrix_read(1, raise_on_partial_result=True)
+
+
+# --- Tests for valid_flag parameter of valuematrix_read() ---
+
+
+class _FakeMCForValuematrixValidFlag:
+    """Stand-in for mc used by valuematrix_read(), records attribute_no_throw() calls."""
+
+    def __init__(self, flags_attribute_exists: bool = True) -> None:
+        self.__flags_attribute_exists = flags_attribute_exists
+        self.attribute_no_throw_calls: list[tuple] = []
+
+    def entity_by_base_name(self, base_name):
+        return type("E", (), {"aid": 1})()
+
+    def attribute_by_base_name(self, entity, name):
+        return type("A", (), {"name": name})()
+
+    def attribute_no_throw(self, entity_or_name, application_or_base_name):
+        self.attribute_no_throw_calls.append((entity_or_name, application_or_base_name))
+        return object() if self.__flags_attribute_exists else None
+
+
+def _make_valuematrix_read_valid_flag_fake(flags_attribute_exists: bool = True):
+    """Build a minimal FakeConI whose mc records attribute_no_throw() calls."""
+
+    class FakeConI:
+        def __init__(self):
+            self.mc = _FakeMCForValuematrixValidFlag(flags_attribute_exists)
+
+        def valuematrix_read(self, vmreq):
+            return object()  # ignored by monkeypatched to_pandas
+
+    return FakeConI()
+
+
+def test_valuematrix_read_valid_flag_none_default_does_not_request_flags(monkeypatch) -> None:
+    """valid_flag defaults to None: 'flags' is neither requested nor even checked for existence."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Time", "Signal"], "values": [[0, 1, 2], [10, 20, 30]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake()
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1)
+
+    # attribute_no_throw is short-circuited away when valid_flag is None
+    assert fake.mc.attribute_no_throw_calls == []
+    assert list(df.columns) == ["Time", "Signal"]
+
+
+def test_valuematrix_read_valid_flag_true_requests_flags_and_masks_default_bitmask(monkeypatch) -> None:
+    """valid_flag=True requests 'flags' and masks values using the default bitmask (15)."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame(
+            {
+                "name": ["Time", "Signal"],
+                "values": [[0, 1, 2, 3], [10, 20, 30, 40]],
+                "flags": [[0, 0, 0, 0], [0, 1, 0, 8]],
+            }
+        )
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=True)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert "flags" not in df.columns
+    assert str(df["Signal"].dtype) == "Int64"
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+    # column without any invalid flags keeps its original (non-nullable) dtype
+    assert str(df["Time"].dtype) == "int64"
+    assert df["Time"].tolist() == [0, 1, 2, 3]
+
+
+def test_valuematrix_read_valid_flag_custom_bitmask_masks_only_matching_bits(monkeypatch) -> None:
+    """A custom integer valid_flag only masks values whose flags match that specific bitmask."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30, 40]], "flags": [[0, 1, 2, 3]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=1)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_valuematrix_read_valid_flag_true_but_attribute_missing_is_ignored(monkeypatch) -> None:
+    """valid_flag=True is silently ignored when AoLocalColumn has no 'flags' base attribute."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=False)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=True)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert "flags" not in df.columns
+    assert str(df["Signal"].dtype) == "int64"
+    assert df["Signal"].tolist() == [10, 20, 30]
+
+
+def test_valuematrix_read_valid_flag_false_also_masks_with_default_bitmask(monkeypatch) -> None:
+    """valid_flag=False is documented to behave like True/None: it still requests and masks with bitmask 15."""
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame({"name": ["Signal"], "values": [[10, 20, 30, 40]], "flags": [[0, 1, 0, 8]]})
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    fake = _make_valuematrix_read_valid_flag_fake(flags_attribute_exists=True)
+    br = BulkReader(fake)  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    df = br.valuematrix_read(1, valid_flag=False)
+
+    assert fake.mc.attribute_no_throw_calls == [("AoLocalColumn", "flags")]
+    assert df["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+# --- Tests for load_flags parameter of query() ---
+
+
+class _FakeMCAttribute:
+    """Stand-in for mc.attribute_no_throw(), controls whether the 'flags' attribute exists."""
+
+    def __init__(self, exists: bool) -> None:
+        self.__exists = exists
+
+    def attribute_no_throw(self, entity_or_name, application_or_base_name):
+        return object() if self.__exists else None
+
+
+def _make_load_flags_query_fake(exists: bool, captured_query: dict):
+    """Build a minimal FakeConI recording the jaquel query passed to data_read_jaquel()."""
+
+    class FakeConI:
+        def __init__(self):
+            self.mc = _FakeMCAttribute(exists)
+
+        def query_data(self, query):
+            return pd.DataFrame(
+                [
+                    {
+                        "id": 1,
+                        "name": "colA",
+                        "independent": False,
+                        "sequence_representation": SeqRepEnum.explicit.value,
+                        "submatrix": 20,
+                        "number_of_rows": 2,
+                    },
+                    {
+                        "id": 2,
+                        "name": "colB",
+                        "independent": False,
+                        "sequence_representation": SeqRepEnum.explicit.value,
+                        "submatrix": 20,
+                        "number_of_rows": 2,
+                    },
+                ]
+            )
+
+        def data_read_jaquel(self, jaquel_query):
+            captured_query.update(jaquel_query)
+            return object()  # ignored by monkeypatched to_pandas
+
+    return FakeConI()
+
+
+def test_query_load_flags_true_requests_and_returns_flags_when_attribute_exists(monkeypatch) -> None:
+    """load_flags=True adds 'flags' to the requested attributes and to the result when the attribute exists."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        # columns order matches attributes dict: id, values, flags
+        return pd.DataFrame([[1, [1, 2], [0, 1]], [2, [3, 4], [1, 0]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert "flags" in captured_query["$attributes"]
+    assert "flags" in merged.columns
+    assert list(merged["flags"]) == [[0, 1], [1, 0]]
+
+
+def test_query_load_flags_false_by_default_does_not_request_flags(monkeypatch) -> None:
+    """load_flags defaults to False: 'flags' must not be requested nor present in the result."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame([[1, [1, 2]], [2, [3, 4]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20})
+
+    assert "flags" not in captured_query["$attributes"]
+    assert "flags" not in merged.columns
+
+
+def test_query_load_flags_true_but_attribute_missing_is_ignored(monkeypatch) -> None:
+    """load_flags=True is silently ignored when AoLocalColumn has no 'flags' base attribute."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        return pd.DataFrame([[1, [1, 2]], [2, [3, 4]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=False, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert "flags" not in captured_query["$attributes"]
+    assert "flags" not in merged.columns
+
+
+def test_query_load_flags_merges_with_metadata_preserving_order(monkeypatch) -> None:
+    """flags values are merged onto the correct row per local column id, preserving bulk order."""
+    captured_query: dict = {}
+
+    def fake_to_pandas(dms, **kwargs):
+        # bulk order is [2, 1] here to make sure merge doesn't rely on sorted ids
+        return pd.DataFrame([[2, [3, 4], [1, 0]], [1, [1, 2], [0, 1]]])
+
+    monkeypatch.setattr("odsbox.bulk_reader.to_pandas", fake_to_pandas)
+    monkeypatch.setattr("odsbox.bulk_reader.extract_column_unit_ids", lambda dms: [])
+
+    br = BulkReader(_make_load_flags_query_fake(exists=True, captured_query=captured_query))  # type: ignore[arg-type]
+    br._unit_name_lookup_cache = {}
+
+    merged = br.query({"submatrix": 20}, load_flags=True)
+
+    assert list(merged["name"]) == ["colB", "colA"]
+    assert list(merged["flags"]) == [[1, 0], [0, 1]]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_false_uses_default_mask() -> None:
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 0, 8],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(False, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_none_uses_default_mask() -> None:
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [1, 2, 3],
+                "flags": [0, 15, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(None, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [1, pd.NA, 3]
+
+
+# --- Tests for valid_flag parameter of data_read() ---
+
+
+def test_data_read_valid_flag_none_default_does_not_request_flags():
+    """valid_flag defaults to None: query() is called with load_flags=False and no masking occurs."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2], "independent": True},
+            {"name": "val", "values": [10, 11, 12], "independent": False},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False)
+
+    assert captured_kwargs["load_flags"] is False
+    assert df["val"].tolist() == [10, 11, 12]
+    assert str(df["val"].dtype) == "int64"
+
+
+def test_data_read_valid_flag_true_requests_flags_and_masks_default_bitmask():
+    """valid_flag=True requests flags from query() and masks values using the default bitmask (15)."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2, 3], "independent": True, "flags": [0, 0, 0, 0]},
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=True)
+
+    assert captured_kwargs["load_flags"] is True
+    assert str(df["val"].dtype) == "Int64"
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+    # column without any invalid flags keeps its original (non-nullable) dtype
+    assert str(df["time"].dtype) == "int64"
+    assert df["time"].tolist() == [0, 1, 2, 3]
+
+
+def test_data_read_valid_flag_custom_bitmask_masks_only_matching_bits():
+    """A custom integer valid_flag only masks values whose flags match that specific bitmask."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 2, 3]},
+        ]
+    )
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=1)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_data_read_valid_flag_false_also_requests_and_masks_with_default_bitmask():
+    """valid_flag=False is documented to behave like True/None: it still requests and masks with bitmask 15."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+    captured_kwargs: dict = {}
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30, 40], "independent": False, "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    def fake_query(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return qdf
+
+    br.query = fake_query
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=False)
+
+    # False is not None, so flags are still requested from query()
+    assert captured_kwargs["load_flags"] is True
+    assert df["val"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_data_read_valid_flag_preserves_unit_names_and_partial_result_attrs():
+    """valid_flag masking must not interfere with existing unit_names/partial_result propagation."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "val", "values": [10, 20, 30], "independent": False, "flags": [0, 1, 0]},
+        ]
+    )
+    qdf.attrs["unit_names"] = {"val": "N"}
+    qdf.attrs["partial_result"] = True
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=False, valid_flag=True)
+
+    assert df.attrs["unit_names"] == {"val": "N"}
+    assert df.attrs["partial_result"] is True
+    assert df["val"].tolist() == [10, pd.NA, 30]
+
+
+def test_data_read_valid_flag_with_independent_index_set():
+    """valid_flag composes correctly with set_independent_as_index=True."""
+    from odsbox.bulk_reader import BulkReader as BR
+
+    br = BR(None)  # type: ignore[arg-type]
+
+    qdf = pd.DataFrame(
+        [
+            {"name": "time", "values": [0, 1, 2], "independent": True, "flags": [0, 0, 0]},
+            {"name": "val", "values": [10, 20, 30], "independent": False, "flags": [0, 1, 0]},
+        ]
+    )
+
+    br.query = lambda *args, **kwargs: qdf
+
+    df = br.data_read(submatrix_iid=1, set_independent_as_index=True, valid_flag=True)
+
+    assert df.index.tolist() == [0, 1, 2]
+    assert list(df.columns) == ["val"]
+    assert df["val"].tolist() == [10, pd.NA, 30]
+
+
+# --- Additional tests for _create_dataframe_from_localcolumns (static method) ---
+
+
+def test_create_dataframe_from_localcolumns_without_flags_column_returns_values_unchanged():
+    """When 'flags' is not part of the metadata, values are used verbatim regardless of valid_flag."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2]},
+            {"name": "Signal", "values": [10, 20, 30]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert list(rv.columns) == ["Time", "Signal"]
+    assert rv["Time"].tolist() == [0, 1, 2]
+    assert rv["Signal"].tolist() == [10, 20, 30]
+    assert str(rv["Signal"].dtype) == "int64"
+
+
+def test_create_dataframe_from_localcolumns_custom_int_bitmask():
+    """A custom integer bitmask only masks values whose flags match that specific mask."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 2, 3],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(1, localcolumn_df)
+
+    # flag=2 does not have bit 0 set, so it stays valid even though bitmask 15 would mask it
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_valid_flag_true_matches_default_mask():
+    """valid_flag=True behaves identically to False/None: all map to the default bitmask 15."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30, 40],
+                "flags": [0, 1, 0, 8],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_no_invalid_flags_keeps_original_dtype():
+    """When no flag matches the bitmask, values keep their original (non-nullable) dtype."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [10, 20, 30],
+                "flags": [0, 0, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "int64"
+    assert rv["Signal"].tolist() == [10, 20, 30]
+
+
+def test_create_dataframe_from_localcolumns_empty_flags_list_skips_masking():
+    """An empty flags list (e.g. a zero-row column) leaves the values untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": [],
+                "flags": [],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert rv["Signal"].tolist() == []
+
+
+def test_create_dataframe_from_localcolumns_float_values_use_nan_for_masked():
+    """Float columns keep their float dtype and use NaN (not pd.NA) for masked entries."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": np.array([1.5, 2.5, 3.5], dtype=float),
+                "flags": [0, 1, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "float64"
+    assert rv["Signal"].iloc[0] == 1.5
+    assert np.isnan(rv["Signal"].iloc[1])
+    assert rv["Signal"].iloc[2] == 3.5
+
+
+def test_create_dataframe_from_localcolumns_boolean_values_use_nullable_boolean():
+    """Boolean columns convert to the nullable BooleanDtype so pd.NA can be stored."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {
+                "name": "Signal",
+                "values": np.array([True, False, True]),
+                "flags": [0, 1, 0],
+            }
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Signal"].dtype) == "boolean"
+    assert rv["Signal"].tolist() == [True, pd.NA, True]
+
+
+def test_create_dataframe_from_localcolumns_multiple_columns_independent_masking():
+    """Each local column's mask is computed independently; unaffected columns are untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 0, 0, 0]},
+            {"name": "Signal", "values": [10, 20, 30, 40], "flags": [0, 1, 0, 8]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "int64"
+    assert rv["Time"].tolist() == [0, 1, 2, 3]
+    assert str(rv["Signal"].dtype) == "Int64"
+    assert rv["Signal"].tolist() == [10, pd.NA, 30, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_constant_flags_shorter_than_values_are_broadcast():
+    """Servers may return 'flags' in the same compact form used for implicit/raw sequence
+    representations (e.g. 2 samples for an implicit_linear column with 4 rows). When every
+    returned flag sample is identical, that single value must apply to every row."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [15, 15]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "Int64"
+    assert rv["Time"].tolist() == [pd.NA, pd.NA, pd.NA, pd.NA]
+
+
+def test_create_dataframe_from_localcolumns_constant_valid_flags_shorter_than_values_no_masking():
+    """A short constant 'flags' sample that does not match the bitmask leaves values untouched."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 0]},
+        ]
+    )
+
+    rv = BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)
+
+    assert str(rv["Time"].dtype) == "int64"
+    assert rv["Time"].tolist() == [0, 1, 2, 3]
+
+
+def test_create_dataframe_from_localcolumns_non_constant_length_mismatch_raises():
+    """A 'flags' array that neither matches the values length nor is constant cannot be aligned."""
+    localcolumn_df = pd.DataFrame(
+        [
+            {"name": "Time", "values": [0, 1, 2, 3], "flags": [0, 15]},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cannot be aligned"):
+        BulkReader._create_dataframe_from_localcolumns(True, localcolumn_df)

--- a/tests/test_bulk_reader_integration.py
+++ b/tests/test_bulk_reader_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -98,6 +99,101 @@ def test_bulk_reader_query():
             assert len(time_vals) > 0
             assert len(coolant_vals) > 0
             assert len(time_vals) == len(coolant_vals)
+
+
+@pytest.mark.integration
+def test_bulk_reader_query_load_flags() -> None:
+    with __create_con_i() as con_i:
+        conditions = {"submatrix.measurement.name": {"$like": "Profile_5?"}}
+        con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"], column_patterns_case_insensitive=False)
+
+        # AoLocalColumn.flags is not requested unless load_flags=True
+        df_without_flags = con_i.bulk.query(conditions, load_flags=False)
+        assert df_without_flags.empty is False
+        assert "flags" not in df_without_flags.columns
+
+        df_with_flags = con_i.bulk.query(conditions, load_flags=True)
+        assert df_with_flags.empty is False
+        assert "flags" in df_with_flags.columns
+        for flags in df_with_flags["flags"]:
+            assert len(flags) > 0
+
+        # requesting flags must not change the other columns/values
+        pd.testing.assert_frame_equal(df_without_flags, df_with_flags.drop(columns=["flags"]))
+
+
+@pytest.mark.integration
+def test_bulk_reader_data_read_valid_flag() -> None:
+    with __create_con_i() as con_i:
+        sm_s = con_i.query_data(
+            {
+                "AoSubmatrix": {"measurement.name": "Profile_52"},
+                "$options": {"$rowlimit": 1},
+                "$attributes": {"id": 1, "measurement.name": 1},
+            }
+        )
+
+        assert sm_s.shape[0] <= 1
+        if 1 == sm_s.shape[0]:
+            submatrix_id = int(sm_s.iloc[0, 0])
+
+            df_plain = con_i.bulk.data_read(submatrix_id, ["Time", "Coolant"], set_independent_as_index=False)
+
+            # independently fetch the raw flags to derive the expected mask
+            conditions = {"submatrix": submatrix_id}
+            con_i.bulk.add_column_filters(conditions, ["Time", "Coolant"], column_patterns_case_insensitive=False)
+            flagged = con_i.bulk.query(conditions, load_flags=True)
+            assert "flags" in flagged.columns
+
+            df_filtered = con_i.bulk.data_read(
+                submatrix_id, ["Time", "Coolant"], set_independent_as_index=False, valid_flag=True
+            )
+
+            assert list(df_filtered.columns) == list(df_plain.columns)
+            for _, row in flagged.iterrows():
+                name = row["name"]
+                flags = np.asarray(row["flags"], dtype=int)
+                if len(flags) != len(df_plain[name]):
+                    # servers may return flags in the same compact form used for implicit/raw
+                    # sequence representations; a constant sample set applies to every row
+                    assert len(np.unique(flags)) == 1
+                    flags = np.full(len(df_plain[name]), flags[0])
+                invalid_mask = (flags & 15) != 0
+                if invalid_mask.any():
+                    assert df_filtered[name].isna().tolist() == invalid_mask.tolist()
+                    assert df_filtered[name][~invalid_mask].tolist() == df_plain[name][~invalid_mask].tolist()
+                else:
+                    pd.testing.assert_series_equal(df_filtered[name], df_plain[name], check_names=False)
+
+
+@pytest.mark.integration
+def test_bulk_reader_valuematrix_read_valid_flag() -> None:
+    with __create_con_i() as con_i:
+        sm_s = con_i.query_data(
+            {
+                "AoSubmatrix": {"measurement.name": "Profile_52"},
+                "$options": {"$rowlimit": 1},
+                "$attributes": {"id": 1, "measurement.name": 1},
+            }
+        )
+
+        assert sm_s.shape[0] <= 1
+        if 1 == sm_s.shape[0]:
+            submatrix_id = int(sm_s.iloc[0, 0])
+
+            # data_read()'s masking is already verified independently above; use it as the
+            # reference to confirm valuematrix_read() applies the same masking for valid_flag.
+            df_data_read = con_i.bulk.data_read(
+                submatrix_id, ["Time", "Coolant"], set_independent_as_index=False, valid_flag=True
+            )
+            df_valuematrix = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Coolant"], valid_flag=True)
+
+            pd.testing.assert_frame_equal(df_data_read, df_valuematrix)
+            assert df_valuematrix.attrs["unit_names"] == df_data_read.attrs["unit_names"]
+
+            # plain read (no valid_flag) must still work and keep the same columns
+            df_plain = con_i.bulk.valuematrix_read(submatrix_id, ["Time", "Coolant"])
+            assert list(df_plain.columns) == list(df_valuematrix.columns)
 
 
 @pytest.mark.integration

--- a/tests/test_submatrix_to_pandas.py
+++ b/tests/test_submatrix_to_pandas.py
@@ -16,6 +16,8 @@ Test map
     - test_passes_set_independent_as_index_false_to_bulk_reader
         Verifies the wrapper correctly forwards `set_independent_as_index=False`
         to `BulkReader.data_read`.
+    - test_passes_valid_flag_to_bulk_reader
+        Verifies the wrapper correctly forwards `valid_flag` to `BulkReader.data_read`.
     - test_can_opt_in_to_set_independent_as_index
         Verifies that passing `set_independent_as_index=True` promotes the
         independent column to the index (opt-in path).
@@ -122,6 +124,24 @@ class TestSubmatrixToPandasDefaultBehavior:
             submatrix_iid=42,
             date_as_timestamp=False,
             set_independent_as_index=False,
+            valid_flag=None,
+        )
+
+    def test_passes_valid_flag_to_bulk_reader(self):
+        """`submatrix_to_pandas` must forward `valid_flag` to `BulkReader.data_read`."""
+        con_i = MagicMock()
+
+        with patch("odsbox.submatrix_to_pandas.BulkReader") as MockBulkReader:
+            mock_br = MockBulkReader.return_value
+            mock_br.data_read.return_value = pd.DataFrame({"time": [0], "speed": [10]})
+
+            submatrix_to_pandas(con_i, submatrix_iid=42, valid_flag=1)
+
+        mock_br.data_read.assert_called_once_with(
+            submatrix_iid=42,
+            date_as_timestamp=False,
+            set_independent_as_index=False,
+            valid_flag=1,
         )
 
     def test_can_opt_in_to_set_independent_as_index(self):

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -640,7 +640,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -706,14 +706,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.55"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]
@@ -839,17 +839,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -866,18 +866,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -889,7 +889,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1092,7 +1092,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -1109,7 +1109,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -1397,12 +1397,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1419,12 +1419,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -1861,8 +1861,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "types-pytz", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "types-pytz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -1879,7 +1879,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
 wheels = [
@@ -2807,23 +2807,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2838,23 +2838,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2870,23 +2870,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -2918,12 +2918,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "starlette", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", marker = "python_full_version < '3.11'" },
-    { name = "watchfiles", marker = "python_full_version < '3.11'" },
-    { name = "websockets", marker = "python_full_version < '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -2940,13 +2940,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "starlette", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", marker = "python_full_version >= '3.11'" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -2989,7 +2989,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -3006,7 +3006,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -1676,7 +1676,7 @@ wheels = [
 
 [[package]]
 name = "odsbox"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -640,7 +640,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -839,17 +839,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -866,18 +866,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -889,7 +889,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1092,7 +1092,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -1109,7 +1109,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -1397,12 +1397,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "jinja2" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "mdit-py-plugins" },
-    { name = "pyyaml" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1419,12 +1419,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "jinja2" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "mdit-py-plugins" },
-    { name = "pyyaml" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -1701,6 +1701,7 @@ dev = [
     { name = "mypy" },
     { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas-stubs", version = "3.0.0.260204", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1749,6 +1750,7 @@ dev = [
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "mypy", specifier = ">=1.20.0" },
     { name = "pandas-stubs", specifier = ">=2.2.0" },
+    { name = "pip", specifier = ">=26.2" },
     { name = "pip-audit", specifier = ">=2.9.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=9.0.0" },
@@ -1861,8 +1863,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -1879,7 +1881,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
 wheels = [
@@ -1927,11 +1929,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -2807,23 +2809,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2838,23 +2840,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2870,23 +2872,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -2918,12 +2920,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "starlette" },
-    { name = "uvicorn" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "colorama", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "starlette", marker = "python_full_version < '3.11'" },
+    { name = "uvicorn", marker = "python_full_version < '3.11'" },
+    { name = "watchfiles", marker = "python_full_version < '3.11'" },
+    { name = "websockets", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -2940,13 +2942,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "starlette" },
-    { name = "uvicorn" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "starlette", marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
+    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
+    { name = "websockets", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -2989,7 +2991,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -3006,7 +3008,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }


### PR DESCRIPTION
This pull request introduces support for quality flag-based filtering when reading bulk data with the `BulkReader` class, improving data integrity and usability. It also adds documentation and minor configuration updates. The most important changes are grouped below.

### Bulk Data Quality Filtering

* Added a `valid_flag` parameter to `BulkReader.data_read()` and `BulkReader.valuematrix_read()`, and a `load_flags` parameter to `BulkReader.query()`, allowing values with quality flags matching a given bitmask to be replaced with missing values (`pd.NA` or `NaN`), preserving DataFrame shape and column dtypes. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R219) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R252-R253) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R373) [[4]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R403-R407) [[5]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R431-R435) [[6]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R448-R481) [[7]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R491) [[8]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R518-R522) [[9]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R539-R552)
* Implemented the `_create_dataframe_from_localcolumns` static method to handle flag-based filtering and ensure columns are upcast to nullable dtypes as needed.
* Updated docstrings and inline documentation to explain the new quality filtering behavior and parameters. [[1]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R65-R70) [[2]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R252-R253) [[3]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R403-R407) [[4]](diffhunk://#diff-ccf52b7e1a36d6d833d7bc23ccde0e02cef1a9a9b22da323a8218cd584113783R518-R522)

### Documentation

* Added a new user guide, `docs/con_read_bulk.md`, covering how to read bulk data, use the new quality filtering features, and handle chunked results and units.
* Included the new documentation page in the table of contents.

### Dependency and Configuration Updates

* Updated the `astral-sh/setup-uv` GitHub Action from version `v9.0.0` to `v10.0.1` in workflow files for improved reliability and compatibility. (.github/workflows/CI.yml: [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L17-R17) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L51-R51) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L74-R74) [[4]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L105-R105); .github/workflows/sphinx.yml: [[5]](diffhunk://#diff-3b5400f13c20505910b5f51111b34c0c17ad7137e82e2859cef6ee5a09e77f8dL17-R17)
* Added `"nullable"` to the list of recognized tokens and set `"chat.disableAIFeatures": false` in `.vscode/settings.json`. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R57) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L74-R76)

These changes make bulk data reading more robust and user-friendly, especially when dealing with quality flags in ASAM ODS data.